### PR TITLE
Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ $ docstr-coverage some_project/src
 	* 1 - Print overall statistics
 	* 2 - Also print individual statistics for each file
 	* 3 - Also print missing docstrings (function names, class names, etc.)
+* *--docstr-ignore-file - Filepath to list of patterns to ignrore. Patterns are file-pattern name-pattern pairs. File content example:
+
+.* add_arguments handle
+detect_.* get_val.*
 
 #### Package in Your Project
 You can also use `docstr-coverage` as a part of your project by importing it thusly:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docstr-coverage some_project/src
 	* 1 - Print overall statistics
 	* 2 - Also print individual statistics for each file
 	* 3 - Also print missing docstrings (function names, class names, etc.)
-* *--docstr-ignore-file - Filepath to list of patterns to ignrore. Patterns are file-pattern name-pattern pairs. File content example:
+* *--docstr-ignore-file - Filepath to list of patterns to ignore. Patterns are file-pattern name-pattern pairs. File content example:
 
 .* add_arguments handle
 detect_.* get_val.*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ $ docstr-coverage some_project/src
 	* 2 - Also print individual statistics for each file
 	* 3 - Also print missing docstrings (function names, class names, etc.)
 * *--docstr-ignore-file=<filepath>, -d <filepath>* - Filepath containing list of patterns to ignore. Patterns are (file-pattern, name-pattern) pairs
-       * File content example:
+       
+    * File content example:
+    ```
+    SomeFile method_to_ignore1 method_to_ignore2 method_to_ignore3
+    FileWhereWeWantToIgnoreAllSpecialMethods __.+__
+    .* method_to_ignore_in_all_files
+    a_very_important_view_file ^get$ ^set$ ^post$
+    ```
 
 .* add_arguments handle
 detect_.* get_val.*

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ $ docstr-coverage some_project/src
 	* 1 - Print overall statistics
 	* 2 - Also print individual statistics for each file
 	* 3 - Also print missing docstrings (function names, class names, etc.)
-* *--docstr-ignore-file - Filepath to list of patterns to ignore. Patterns are file-pattern name-pattern pairs. File content example:
+* *--docstr-ignore-file=<filepath>, -d <filepath>* - Filepath containing list of patterns to ignore. Patterns are (file-pattern, name-pattern) pairs
+       * File content example:
 
 .* add_arguments handle
 detect_.* get_val.*

--- a/README.md
+++ b/README.md
@@ -73,13 +73,8 @@ $ docstr-coverage some_project/src
     FileWhereWeWantToIgnoreAllSpecialMethods __.+__
     .* method_to_ignore_in_all_files
     a_very_important_view_file ^get$ ^set$ ^post$
+    detect_.* get_val.*
     ```
-
-.* add_arguments handle
-detect_.* get_val.*
-^test_.* ^test.*
-
-(And after that all methods with "test" at the beginning of all "test_sth" files will be ignored.)
 
 #### Package in Your Project
 You can also use `docstr-coverage` as a part of your project by importing it thusly:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ $ docstr-coverage some_project/src
 
 .* add_arguments handle
 detect_.* get_val.*
+^test_.* ^test.*
+
+(And after that all methods with "test" at the beginning of all "test_sth" files will be ignored.)
 
 #### Package in Your Project
 You can also use `docstr-coverage` as a part of your project by importing it thusly:

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -7,6 +7,7 @@ from pprint import pprint as pp
 import re
 import sys
 from pathlib import Path
+from pathlib import Path
 
 class DocStringCoverageVisitor(NodeVisitor):
     """Class to visit nodes, determine whether a node requires a docstring, and to check for the existence of a docstring"""

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -3,11 +3,10 @@
 # TODO: If Python 2, ```from __future__ import print_function```
 from ast import NodeVisitor, parse, get_docstring
 import os
-from pprint import pprint as pp
 import re
 import sys
 from pathlib import Path
-from pathlib import Path
+
 
 class DocStringCoverageVisitor(NodeVisitor):
     """Class to visit nodes, determine whether a node requires a docstring, and to check for the existence of a docstring"""

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -420,7 +420,7 @@ def _execute():
 
     ignore_names = ()
 
-    if options.ignore_names_file == '.docstr_coverage':
+    if options.ignore_names_file == ".docstr_coverage":
         options.ignore_names_file = Path(path, options.ignore_names_file)
 
     if os.path.isfile(options.ignore_names_file):

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -194,7 +194,7 @@ def get_docstring_coverage(
         file_missing_list = []
 
         #################### Read and Parse Source ####################
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding='utf-8') as f:
             source_tree = f.read()
 
         doc_visitor = DocStringCoverageVisitor()

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -403,6 +403,7 @@ def _execute():
 
     if path.endswith(".py"):
         filenames = [path]
+        path = "."
     else:
         for root, dirs, f_names in os.walk(path, followlinks=options.follow_links):
             if exclude_re is not None:

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -172,7 +172,7 @@ def get_docstring_coverage(
             elif skip_class_def and "_" not in name and (name[0] == name[0].upper()):
                 docs_needed -= 1
             elif ignore_names:
-                filename = os.path.basename(filename).split(".")[0] if "." in filename else filename
+                filename = os.path.basename(filename).split(".")[0]
                 for line in ignore_names:
                     file_regex = line[0]
                     name_regex_list = list(line[1:])

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -386,7 +386,7 @@ def _execute():
         dest="ignore_names_file",
         default=".docstr_coverage",
         type="string",
-        help="A path to filename where list of regexes (file name) occurs."
+        help="Filepath containing list of regex (file-pattern, name-pattern) pairs"
     )
     # TODO: Separate above arg/option parsing into separate function - Document return values to describe allowed options
     options, args = parser.parse_args()

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -172,19 +172,20 @@ def get_docstring_coverage(
             elif skip_class_def and "_" not in name and (name[0] == name[0].upper()):
                 docs_needed -= 1
             elif ignore_names:
-                filename = filename.split("\\")[-1].split(".")[0]
+                filename = os.path.basename(filename).split(".")[0] if "." in filename else filename
                 for line in ignore_names:
                     file_regex = line[0]
                     name_regex_list = list(line[1:])
                     file_match = re.fullmatch(file_regex, filename)
                     file_match = file_match.group() if file_match else None
-                    if file_match == filename:
-                        for name_regex in name_regex_list:
-                            name_match = re.fullmatch(name_regex, name)
-                            name_match = name_match.group() if name_match else None
-                            if name_match:
-                                docs_needed -= 1
-                                break
+                    if file_match != filename:
+                        continue
+                    for name_regex in name_regex_list:
+                        name_match = re.fullmatch(name_regex, name)
+                        name_match = name_match.group() if name_match else None
+                        if name_match:
+                            docs_needed -= 1
+                            break
             else:
                 log(" - No docstring for `%s%s`" % (base, name), 3)
                 _missing_list.append(base + name)

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -380,7 +380,6 @@ def _execute():
         default=False,
         help="Follow symlinks",
     )
-
     parser.add_option(
         "-d",
         "--docstr-ignore-file",

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -173,6 +173,7 @@ def get_docstring_coverage(
                 docs_needed -= 1
             elif ignore_names:
                 filename = os.path.basename(filename).split(".")[0]
+                already_ignored = []
                 for line in ignore_names:
                     file_regex = line[0]
                     name_regex_list = list(line[1:])
@@ -183,7 +184,11 @@ def get_docstring_coverage(
                     for name_regex in name_regex_list:
                         name_match = re.fullmatch(name_regex, name)
                         name_match = name_match.group() if name_match else None
+                        ignore_tuple = (filename, name_match)
+                        if ignore_tuple in already_ignored:
+                            continue
                         if name_match:
+                            already_ignored.append(ignore_tuple)
                             docs_needed -= 1
                             break
             else:
@@ -418,7 +423,7 @@ def _execute():
 
     if options.ignore_names_file == '.docstr_coverage':
         options.ignore_names_file = Path(path, options.ignore_names_file)
-    
+
     if os.path.isfile(options.ignore_names_file):
         ignore_names = tuple([line.split() for line in open(options.ignore_names_file).readlines() if ' ' in line])
 

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -140,12 +140,12 @@ def get_docstring_coverage(
         node: Tuple triple of (String, Boolean, List)
             Information describing a node. `node[0]` is the node's name. `node[1]` is True if the node was properly documented,
             else False. `node[3]` is a list containing the node's children as triples of the same form (if it had any)
+        filename: String
+            String containing a name of file.
         ignore_names: tuple of lists ([String, String, [String...]]) where the first element is the regular expression
             for matching filenames. All remaining arguments are regexes for matching names of functions/classes
             to be excluded from checking for documentation. It will be excluded if and only if the first and at least
             one of the remaining regexes hits a match.
-        filename: String
-            String containing a name of file.
 
         Returns
         -------


### PR DESCRIPTION
I added support for regex exclude names in regex matched files. With it I can put for example:
^test_.* ^test.*
And after that all methods with "test" at the beginning of all "test_sth" files will be ignored.