### PR TITLE
Add option to fail when coverage is under a given amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ $ docstr-coverage some_project/src
 	* 2 - Also print individual statistics for each file
 	* 3 - Also print missing docstrings (function names, class names, etc.)
 * *--docstr-ignore-file=<filepath>, -d <filepath>* - Filepath containing list of patterns to ignore. Patterns are (file-pattern, name-pattern) pairs
+* *--fail-under=<int|float>, -F <int|float>* - Fail if under a certain percentage of coverage (default: 100.0)
        
     * File content example:
     ```

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -388,6 +388,15 @@ def _execute():
         type="string",
         help="Filepath containing list of regex (file-pattern, name-pattern) pairs"
     )
+    parser.add_option(
+        "-F",
+        "--failunder",
+        dest="fail_under",
+        type="float",
+        default=100.0,
+        metavar="FLOAT",
+        help="Fail when coverage % is less than a given amount (default: 100.0)",
+    )
     # TODO: Separate above arg/option parsing into separate function - Document return values to describe allowed options
     options, args = parser.parse_args()
 
@@ -437,7 +446,7 @@ def _execute():
         ignore_names=ignore_names,
     )
 
-    if total_results['coverage'] != 100.0:
+    if total_results['coverage'] < options.fail_under:
         raise SystemExit(1)
 
     raise SystemExit(0)


### PR DESCRIPTION
Hey there - I found myself wanting something similar to [`coverage.py`'s `--fail-under`](https://coverage.readthedocs.io/en/coverage-5.1/cmd.html#reporting) flag, so I am proposing to add another option. I tried to keep within the current option-naming style. LMK if you'd like anything changed.

Example usage:

```sh
# don't fail even though it's shitty coverage
$ docstr-coverage -F 19 src/metrics/stackdriver.py

File: "src/metrics/stackdriver.py"
 - No docstring for `StackdriverLogMetricsClient`
 - No docstring for `StackdriverLogMetricsClient.__init__`
 - No docstring for `StackdriverLogMetricsClient._stackdriver_client`
 - No docstring for `StackdriverLogMetricsClient.counter`
 - No docstring for `StackdriverLogMetricsClient.gauge`
 - No docstring for `StackdriverLogMetricsClient.timer`
 - No docstring for `StackdriverLogMetricsCounter`
 - No docstring for `StackdriverLogMetricsCounter.__init__`
 - No docstring for `StackdriverLogMetricsCounter._get_filter`
 - No docstring for `StackdriverLogMetricsCounter._get_transform_label_extractor`
 - No docstring for `StackdriverLogMetricsCounter._get_body`
 - No docstring for `StackdriverLogMetricsCounter._init_metric`
 Needed: 15; Found: 3; Missing: 12; Coverage: 20.0%


Overall statistics:
Docstrings needed: 15; Docstrings found: 3; Docstrings missing: 12
Total docstring coverage: 20.0%;  Grade: Extremely poor

$ echo $?
0
```

```sh
# do fail because I should be embarrassed
$ docstr-coverage -F 21 src/metrics/stackdriver.py

File: "src/metrics/stackdriver.py"
 - No docstring for `StackdriverLogMetricsClient`
 - No docstring for `StackdriverLogMetricsClient.__init__`
 - No docstring for `StackdriverLogMetricsClient._stackdriver_client`
 - No docstring for `StackdriverLogMetricsClient.counter`
 - No docstring for `StackdriverLogMetricsClient.gauge`
 - No docstring for `StackdriverLogMetricsClient.timer`
 - No docstring for `StackdriverLogMetricsCounter`
 - No docstring for `StackdriverLogMetricsCounter.__init__`
 - No docstring for `StackdriverLogMetricsCounter._get_filter`
 - No docstring for `StackdriverLogMetricsCounter._get_transform_label_extractor`
 - No docstring for `StackdriverLogMetricsCounter._get_body`
 - No docstring for `StackdriverLogMetricsCounter._init_metric`
 Needed: 15; Found: 3; Missing: 12; Coverage: 20.0%


Overall statistics:
Docstrings needed: 15; Docstrings found: 3; Docstrings missing: 12
Total docstring coverage: 20.0%;  Grade: Extremely poor

$ echo $?
1
```