### PR TITLE
Allow to override 'docstring missing' from sourcecode for classes and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ docstr-coverage some_project/src
   ```
 - _--badge=\<filepath\>, -b \<filepath\>_ - Generate a docstring coverage percent badge as an SVG saved to a given filepath
 
+
+#### Overriding by comments
+Note that `docstr-coverage` performs static code analysis to count docstrings. 
+Thus, dynamically added documentation (e.g. through class extension) will not be counted by default.
+You can take account of this by adding either `#docstring_coverage:inherited`
+or something like `#docstring_coverage:excused 'My probably bad excuse'` 
+in the line above any class or function definition.
+Such class or function would then be counted as if they had a docstring below them.
+
+```python
+# docstring_cov:excused 'no one is reading this anyways'
+class FooBarChild(FooBar):
+
+    # docstr_cov:inherited
+    def function(self):
+        pass
+```
+
+*Note*: While some variation in these comments is accounted for (e.g. `#docstr_cov:inherit` is valid as well),
+any comment must be either an `inherit` or `excuse`, and for excuse a reason within " " or ' ' must be provided.
+
 #### Package in Your Project
 
 You can also use `docstr-coverage` as a part of your project by importing it thusly:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Note that `docstr-coverage` performs static code analysis to count docstrings.
 Thus, dynamically added documentation (e.g. through class extension) will not be counted by default.
 You can take account of this by adding either `#docstring_coverage:inherited`
 or something like `#docstring_coverage:excused 'My probably bad excuse'` 
-in the line above any class or function definition.
+in the line above any class or function definition (or above annotations, if applicable).
 Such class or function would then be counted as if they had a docstring below them.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ docstr-coverage some_project/src
   ```
 - _--badge=\<filepath\>, -b \<filepath\>_ - Generate a docstring coverage percent badge as an SVG saved to a given filepath
 
-
-#### Overriding by comments
+#### Overriding by Comments
 Note that `docstr-coverage` performs static code analysis to count docstrings. 
 Thus, dynamically added documentation (e.g. through class extension) will not be counted by default.
 You can take account of this by adding either `#docstring_coverage:inherited`

--- a/README.md
+++ b/README.md
@@ -81,24 +81,25 @@ docstr-coverage some_project/src
 - _--badge=\<filepath\>, -b \<filepath\>_ - Generate a docstring coverage percent badge as an SVG saved to a given filepath
 
 #### Overriding by Comments
-Note that `docstr-coverage` performs static code analysis to count docstrings. 
-Thus, dynamically added documentation (e.g. through class extension) will not be counted by default.
-You can take account of this by adding either `#docstring_coverage:inherited`
-or something like `#docstring_coverage:excused 'My probably bad excuse'` 
-in the line above any class or function definition (or above annotations, if applicable).
-Such class or function would then be counted as if they had a docstring below them.
+Note that `docstr-coverage` can not parse 
+dynamically added documentation (e.g. through class extension).
+Thus, some of your code which deliberately has no docstring might be counted as uncovered.
+
+You can override this by adding either ```#docstr_coverage:inherited``` 
+(intended for use if a docstring is provided in the corresponding superclass method)
+or a generic excuse with a reason, like ```#docstr_coverage:excused `My probably bad excuse` ```.
+These have to be stated right above any class or function definition 
+(or above the functions annotations, if applicable).
+Such class or function would then be counted as if they had a docstring.
 
 ```python
-# docstring_cov:excused 'no one is reading this anyways'
+# docstr-coverage:excused `no one is reading this anyways`
 class FooBarChild(FooBar):
 
-    # docstr_cov:inherited
+    # docstr-coverage:inherited
     def function(self):
         pass
 ```
-
-*Note*: While some variation in these comments is accounted for (e.g. `#docstr_cov:inherit` is valid as well),
-any comment must be either an `inherit` or `excuse`, and for excuse a reason within " " or ' ' must be provided.
 
 #### Package in Your Project
 

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -252,7 +252,7 @@ def get_docstring_coverage(
         with open(filename, "r", encoding="utf-8") as f:
             source_tree = f.read()
 
-        doc_visitor = DocStringCoverageVisitor()
+        doc_visitor = DocStringCoverageVisitor(filename=filename)
         doc_visitor.visit(parse(source_tree))
         _tree = doc_visitor.tree[0]
         # pp(_tree)

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -5,7 +5,7 @@ from ast import NodeVisitor, get_docstring, FunctionDef, ClassDef, Module
 
 ACCEPTED_EXCUSE_PATTERNS = (
     re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*inherit(ed)?\s*"),
-    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse(d)?\s* [\"\'].*[\"\']\s*")
+    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse(d)?\s* [\"\'].*[\"\']\s*"),
 )
 
 
@@ -15,7 +15,7 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     def __init__(self, filename):
         self.filename = filename
-        with open(filename, 'rb') as file:
+        with open(filename, "rb") as file:
             self.tokens = list(tokenize.tokenize(file.readline))
         self.symbol_count = 0
         self.tree = []
@@ -55,19 +55,15 @@ class DocStringCoverageVisitor(NodeVisitor):
     @staticmethod
     def _is_excuse_token(token):
         """Evaluates, for the given tokenizer.token if said token represents a valid excuse comment."""
-        return (
-                token.type == tokenize.COMMENT
-                and any(regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS)
+        return token.type == tokenize.COMMENT and any(
+            regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS
         )
 
     @staticmethod
     def _is_skip_token(token):
         """Evaluates, for the given tokenize.token,
         if said token is expected between a node start and an excuse token."""
-        return (
-                token.type == tokenize.NL
-                or token.type == tokenize.NEWLINE
-        )
+        return token.type == tokenize.NL or token.type == tokenize.NEWLINE
 
     def _has_excuse(self, node):
         """Iterates through the tokenize tokens above the passed node to evaluate whether a
@@ -76,9 +72,10 @@ class DocStringCoverageVisitor(NodeVisitor):
         if node_start < 0:
             # The node started on line 0 and has thus no excuse line
             return False
-        assert node_start < len(self.tokens), \
-            "An unexpected context occurred during parsing of {} " \
-            "It seems not all file lines were tokenized for comment checking.".format(self.filename)
+        assert node_start < len(self.tokens), (
+            "An unexpected context occurred during parsing of {} "
+            "It seems not all file lines were tokenized for comment checking."
+        ).format(self.filename)
 
         token_index = -1
         for i, t in enumerate(self.tokens):

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -75,9 +75,6 @@ class DocStringCoverageVisitor(NodeVisitor):
         """Iterates through the tokenize tokens above the passed node to evaluate whether a
         doc-missing excuse has been placed (right) above this nodes begin"""
         node_start = node.lineno
-        if node_start < 0:
-            # The node started on line 0 and has thus no excuse line
-            return False
         assert node_start < len(self.tokens), (
             "An unexpected context occurred during parsing of {} "
             "It seems not all file lines were tokenized for comment checking."

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -65,7 +65,12 @@ class DocStringCoverageVisitor(NodeVisitor):
     def _is_skip_token(token):
         """Evaluates, for the given tokenize.token,
         if said token is expected between a node start and an excuse token."""
-        return token.type == tokenize.NL or token.type == tokenize.NEWLINE
+        return (
+            token.type == tokenize.NL
+            or token.type == tokenize.NEWLINE
+            or (token.type == tokenize.NAME and token.string == "class")
+            or token.line.strip().startswith("@")
+        )
 
     def _has_excuse(self, node):
         """Iterates through the tokenize tokens above the passed node to evaluate whether a

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -92,7 +92,7 @@ class DocStringCoverageVisitor(NodeVisitor):
 
         # Iterate downwards on token index
         #   (i.e., skip tokens which we expect to see between excuse and node start)
-        #   until we either found a en excuse
+        #   until we find either an excuse
         #   or some token which shows that there was no excuse present.
         while token_index >= 0:
             as_token = self.tokens[token_index]

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -5,7 +5,7 @@ from ast import NodeVisitor, get_docstring, FunctionDef, ClassDef, Module
 
 ACCEPTED_EXCUSE_PATTERNS = (
     re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*inherit(ed)?\s*"),
-    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse\s* [\"\'].*[\"\']\s*")
+    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse(d)?\s* [\"\'].*[\"\']\s*")
 )
 
 

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -55,8 +55,7 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _is_excuse_token(token):
-        """Evaluates, for the given tokenize.token
-        if said token represents a valid excuse comment"""
+        """Evaluates whether the given `tokenize.token` represents a valid excuse comment"""
         return token.type == tokenize.COMMENT and any(
             regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS
         )

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -77,8 +77,9 @@ class DocStringCoverageVisitor(NodeVisitor):
             # The node started on line 0 and has thus no excuse line
             return False
         assert node_start < len(self.tokens), \
-            f"An unexpected context occurred during parsing of {self.filename} " \
-            "It seems not all file lines were tokenized for comment checking."
+            "An unexpected context occurred during parsing of {} " \
+            "It seems not all file lines were tokenized for comment checking.".format(self.filename)
+
         token_index = -1
         for i, t in enumerate(self.tokens):
             if t.start[0] == node_start:

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -49,10 +49,12 @@ class DocStringCoverageVisitor(NodeVisitor):
         self.tree.pop()
 
     def _has_doc_or_excuse(self, node):
+        """Evaluates if the passed not has a corresponding docstring or if there is an excuse comment."""
         return self._has_docstring(node=node) or self._has_excuse(node=node)
 
     @staticmethod
     def _is_excuse_token(token):
+        """Evaluates, for the given tokenizer.token if said token represents a valid excuse comment."""
         return (
                 token.type == tokenize.COMMENT
                 and any(regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS)
@@ -60,12 +62,16 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _is_skip_token(token):
+        """Evaluates, for the given tokenize.token,
+        if said token is expected between a node start and an excuse token."""
         return (
                 token.type == tokenize.NL
                 or token.type == tokenize.NEWLINE
         )
 
     def _has_excuse(self, node):
+        """Iterates through the tokenize tokens above the passed node to evaluate whether a
+        doc-missing excuse has been placed (right) above this nodes begin."""
         node_start = node.lineno
         if node_start < 0:
             # The node started on line 0 and has thus no excuse line
@@ -90,4 +96,5 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _has_docstring(node):
+        """Uses ast to check if the passed not contains a non-empty docstring"""
         return get_docstring(node) is not None and get_docstring(node).strip() != ""

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -96,5 +96,5 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _has_docstring(node):
-        """Uses ast to check if the passed not contains a non-empty docstring"""
+        """Uses ast to check if the passed not contains a non-empty docstring."""
         return get_docstring(node) is not None and get_docstring(node).strip() != ""

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -4,8 +4,8 @@ import tokenize
 from ast import NodeVisitor, get_docstring, FunctionDef, ClassDef, Module
 
 ACCEPTED_EXCUSE_PATTERNS = (
-    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*inherit(ed)?\s*"),
-    re.compile(r"#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse(d)?\s* [\"\'].*[\"\']\s*"),
+    re.compile(r"#\s*docstr-coverage\s*:\s*inherit(ed)?\s*"),
+    re.compile(r"#\s*docstr-coverage\s*:\s*excuse(d)?\s* `.*`\s*"),
 )
 
 

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -1,19 +1,29 @@
 """This module handles traversing abstract syntax trees to check for docstrings"""
+import re
+import tokenize
 from ast import NodeVisitor, get_docstring, FunctionDef, ClassDef, Module
+
+ACCEPTED_EXCUSE_PATTERNS = (
+    re.compile("#\s*docstr(ing)?_cov(erage)?\s*:\s*inherit(ed)?\s*"),
+    re.compile("#\s*docstr(ing)?_cov(erage)?\s*:\s*excuse\s* [\"\'].*[\"\']\s*")
+)
 
 
 class DocStringCoverageVisitor(NodeVisitor):
     """Class to visit nodes, determine whether a node requires a docstring,
     and to check for the existence of a docstring"""
 
-    def __init__(self):
+    def __init__(self, filename):
+        self.filename = filename
+        with open(filename, 'rb') as file:
+            self.line_tokens = list(tokenize.tokenize(file.readline))
         self.symbol_count = 0
         self.tree = []
 
     def visit_Module(self, node: Module):
         """Upon visiting a module, initialize :attr:`DocStringCoverageVisitor.tree`
         with module-wide node info."""
-        has_doc = get_docstring(node) is not None and get_docstring(node).strip() != ""
+        has_doc = self._has_docstring(node)
         is_empty = not len(node.body)
         self.tree.append((has_doc, is_empty, []))
         self.generic_visit(node)
@@ -31,9 +41,33 @@ class DocStringCoverageVisitor(NodeVisitor):
         documentation information for `node`, then ensure all child nodes are
         also visited"""
         self.symbol_count += 1
-        has_doc = get_docstring(node) is not None and get_docstring(node).strip() != ""
+        has_doc = self._has_doc_or_excuse(node)
         _node = (node.name, has_doc, [])
         self.tree[-1][-1].append(_node)
         self.tree.append(_node)
         self.generic_visit(node)
         self.tree.pop()
+
+    def _has_doc_or_excuse(self, node):
+        return self._has_docstring(node=node) or self._has_excuse(node=node)
+
+    def _has_excuse(self, node):
+        excuse_line = node.lineno - 1
+        if excuse_line < 0:
+            # The node started on line 0 and has thus no excuse line
+            return False
+        assert excuse_line < len(self.line_tokens), \
+            f"An unexpected context occurred during parsing of {self.filename} " \
+            "It seems not all file lines were tokenized for comment checking."
+        as_token = self.line_tokens[excuse_line]
+        return (
+                as_token.type == tokenize.COMMENT
+                and any(regex.match(as_token.string) for regex in ACCEPTED_EXCUSE_PATTERNS)
+        )
+
+    @staticmethod
+    def _has_docstring(node):
+        return get_docstring(node) is not None and get_docstring(node).strip() != ""
+
+
+

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -50,13 +50,13 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     def _has_doc_or_excuse(self, node):
         """Evaluates if the passed not has a corresponding docstring
-        or if there is an excuse comment."""
+        or if there is an excuse comment"""
         return self._has_docstring(node=node) or self._has_excuse(node=node)
 
     @staticmethod
     def _is_excuse_token(token):
         """Evaluates, for the given tokenizer.token
-        if said token represents a valid excuse comment."""
+        if said token represents a valid excuse comment"""
         return token.type == tokenize.COMMENT and any(
             regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS
         )
@@ -64,7 +64,7 @@ class DocStringCoverageVisitor(NodeVisitor):
     @staticmethod
     def _is_skip_token(token):
         """Evaluates, for the given tokenize.token,
-        if said token is expected between a node start and an excuse token."""
+        if said token is expected between a node start and an excuse token"""
         return (
             token.type == tokenize.NL
             or token.type == tokenize.NEWLINE
@@ -74,7 +74,7 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     def _has_excuse(self, node):
         """Iterates through the tokenize tokens above the passed node to evaluate whether a
-        doc-missing excuse has been placed (right) above this nodes begin."""
+        doc-missing excuse has been placed (right) above this nodes begin"""
         node_start = node.lineno
         if node_start < 0:
             # The node started on line 0 and has thus no excuse line
@@ -101,5 +101,5 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _has_docstring(node):
-        """Uses ast to check if the passed not contains a non-empty docstring."""
+        """Uses ast to check if the passed not contains a non-empty docstring"""
         return get_docstring(node) is not None and get_docstring(node).strip() != ""

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -49,12 +49,14 @@ class DocStringCoverageVisitor(NodeVisitor):
         self.tree.pop()
 
     def _has_doc_or_excuse(self, node):
-        """Evaluates if the passed not has a corresponding docstring or if there is an excuse comment."""
+        """Evaluates if the passed not has a corresponding docstring
+        or if there is an excuse comment."""
         return self._has_docstring(node=node) or self._has_excuse(node=node)
 
     @staticmethod
     def _is_excuse_token(token):
-        """Evaluates, for the given tokenizer.token if said token represents a valid excuse comment."""
+        """Evaluates, for the given tokenizer.token
+        if said token represents a valid excuse comment."""
         return token.type == tokenize.COMMENT and any(
             regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS
         )

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -55,7 +55,7 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _is_excuse_token(token):
-        """Evaluates, for the given tokenizer.token
+        """Evaluates, for the given tokenize.token
         if said token represents a valid excuse comment"""
         return token.type == tokenize.COMMENT and any(
             regex.match(token.string) for regex in ACCEPTED_EXCUSE_PATTERNS
@@ -84,12 +84,17 @@ class DocStringCoverageVisitor(NodeVisitor):
             "It seems not all file lines were tokenized for comment checking."
         ).format(self.filename)
 
+        # Find the index of first token which starts at the same line as the node
         token_index = -1
         for i, t in enumerate(self.tokens):
             if t.start[0] == node_start:
                 token_index = i - 1
                 break
 
+        # Iterate downwards on token index
+        #   (i.e., skip tokens which we expect to see between excuse and node start)
+        #   until we either found a en excuse
+        #   or some token which shows that there was no excuse present.
         while token_index >= 0:
             as_token = self.tokens[token_index]
             if self._is_skip_token(as_token):
@@ -101,5 +106,5 @@ class DocStringCoverageVisitor(NodeVisitor):
 
     @staticmethod
     def _has_docstring(node):
-        """Uses ast to check if the passed not contains a non-empty docstring"""
+        """Uses ast to check if the passed node contains a non-empty docstring"""
         return get_docstring(node) is not None and get_docstring(node).strip() != ""

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -49,7 +49,7 @@ class DocStringCoverageVisitor(NodeVisitor):
         self.tree.pop()
 
     def _has_doc_or_excuse(self, node):
-        """Evaluates if the passed not has a corresponding docstring
+        """Evaluates if the passed node has a corresponding docstring
         or if there is an excuse comment"""
         return self._has_docstring(node=node) or self._has_excuse(node=node)
 

--- a/tests/excused_samples/fully_excused.py
+++ b/tests/excused_samples/fully_excused.py
@@ -1,4 +1,5 @@
-""" Ignoring module docstrings is not yet supported. However, belows classes and functions docs are."""
+""" Ignoring module docstrings is not yet supported.
+However, belows classes and functions docs are."""
 
 import abc
 

--- a/tests/excused_samples/fully_excused.py
+++ b/tests/excused_samples/fully_excused.py
@@ -1,5 +1,4 @@
-""" Ignoring module docstrings is not yet supported.
-However, belows classes and functions docs are."""
+"""This is a module docstring"""
 
 import abc
 

--- a/tests/excused_samples/fully_excused.py
+++ b/tests/excused_samples/fully_excused.py
@@ -1,0 +1,33 @@
+""" Ignoring module docstrings is not yet supported. However, belows classes and functions docs are."""
+
+import abc
+
+
+# docstr_cov:excuse 'no one is reading this anyways'
+class FooBar:
+
+    # docstring_cov : excuse 'I'm super lazy'
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    #   docstring_cov:excuse '..., I really am...'
+    def function(self):
+        pass
+
+    # docstring_coverage:excuse '...you can't imagine how much...'
+    def prop(self):
+        pass
+
+
+# docstr_cov:excuse '... besides: who's checking anyways'
+def bar():
+    pass
+
+
+# docstring_cov:excuse 'no one is reading this anyways'
+class FooBarChild(FooBar):
+
+    # docstr_cov:inherited
+    def function(self):
+        pass

--- a/tests/excused_samples/fully_excused.py
+++ b/tests/excused_samples/fully_excused.py
@@ -11,8 +11,8 @@ class FooBar:
     def __init__(self):
         pass
 
-    @abc.abstractmethod
     #   docstring_cov:excuse '..., I really am...'
+    @abc.abstractmethod
     def function(self):
         pass
 

--- a/tests/excused_samples/fully_excused.py
+++ b/tests/excused_samples/fully_excused.py
@@ -4,31 +4,31 @@ However, belows classes and functions docs are."""
 import abc
 
 
-# docstr_cov:excuse 'no one is reading this anyways'
+# docstr-coverage:excuse `no one is reading this anyways`
 class FooBar:
 
-    # docstring_cov : excuse 'I'm super lazy'
+    # docstr-coverage : excuse `I'm super lazy`
     def __init__(self):
         pass
 
-    #   docstring_cov:excuse '..., I really am...'
+    #   docstr-coverage:excuse `..., I really am...`
     @abc.abstractmethod
     def function(self):
         pass
 
-    # docstring_coverage:excuse '...you can't imagine how much...'
+    # docstr-coverage:excuse `...you can't imagine how much...`
     def prop(self):
         pass
 
 
-# docstr_cov:excuse '... besides: who's checking anyways'
+# docstr-coverage:excuse `... besides: who's checking anyways`
 def bar():
     pass
 
 
-# docstring_cov:excuse 'no one is reading this anyways'
+# docstr-coverage:excuse `no one is reading this anyways`
 class FooBarChild(FooBar):
 
-    # docstr_cov:inherited
+    # docstr-coverage:inherited
     def function(self):
         pass

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -4,17 +4,17 @@ However, belows classes and functions docs are."""
 import abc
 
 
-# docstring_cov:excuse 'no one is reading this anyways'
+# docstr-coverage:excuse `no one is reading this anyways`
 class FooBar:
     def __init__(self):
         pass
 
-    # docstring_cov:excuse '..., I really am...'
+    # docstr-coverage:excuse `..., I really am...`
     @abc.abstractmethod
     def function(self):
         pass
 
-    # docstring_coverage:excuse '...you can't imagine how much...'
+    # docstr-coverage:excuse `...you can't imagine how much...`
     def prop(self):
         pass
 
@@ -26,6 +26,6 @@ def bar():
 class FooBarChild(FooBar):
     """ Wow! A docstring. Crazy """
 
-    # docstr_cov:inherited
+    # docstr-coverage:inherited
     def function(self):
         pass

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -5,7 +5,6 @@ import abc
 
 # docstring_cov:excuse 'no one is reading this anyways'
 class FooBar:
-
     def __init__(self):
         pass
 

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -1,4 +1,5 @@
-""" Ignoring module docstrings is not yet supported. However, belows classes and functions docs are."""
+""" Ignoring module docstrings is not yet supported.
+However, belows classes and functions docs are."""
 
 import abc
 

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -1,0 +1,31 @@
+""" Ignoring module docstrings is not yet supported. However, belows classes and functions docs are."""
+
+import abc
+
+
+# docstring_cov:excuse 'no one is reading this anyways'
+class FooBar:
+
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    #   docstring_cov:excuse '..., I really am...'
+    def function(self):
+        pass
+
+    # docstring_coverage:excuse '...you can't imagine how much...'
+    def prop(self):
+        pass
+
+
+def bar():
+    pass
+
+
+class FooBarChild(FooBar):
+    """ Wow! A docstring. Crazy """
+
+    # docstr_cov:inherited
+    def function(self):
+        pass

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -1,5 +1,4 @@
-""" Ignoring module docstrings is not yet supported.
-However, belows classes and functions docs are."""
+"""This is a module docstring"""
 
 import abc
 

--- a/tests/excused_samples/partially_excused.py
+++ b/tests/excused_samples/partially_excused.py
@@ -9,8 +9,8 @@ class FooBar:
     def __init__(self):
         pass
 
+    # docstring_cov:excuse '..., I really am...'
     @abc.abstractmethod
-    #   docstring_cov:excuse '..., I really am...'
     def function(self):
         pass
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -34,9 +34,9 @@ def test_should_report_for_an_empty_file():
     assert total_results == {"missing_count": 0, "needed_count": 0, "coverage": 100}
 
 
-@pytest.mark.parametrize("file_path,needed_count",
-                         [(DOCUMENTED_FILE_PATH, 9),
-                          (FULLY_EXCUSED_FILE_PATH, 8)])
+@pytest.mark.parametrize(
+    "file_path,needed_count", [(DOCUMENTED_FILE_PATH, 9), (FULLY_EXCUSED_FILE_PATH, 8)]
+)
 def test_should_report_full_coverage(file_path, needed_count):
     file_results, total_results = get_docstring_coverage([file_path])
     assert file_results == {
@@ -52,10 +52,16 @@ def test_should_report_full_coverage(file_path, needed_count):
     assert total_results == {"missing_count": 0, "needed_count": needed_count, "coverage": 100.0}
 
 
-@pytest.mark.parametrize("file_path,  missing, module_doc,missing_count, needed_count, coverage",
-                         [(PARTLY_DOCUMENTED_FILE_PATH, ["FooBar.__init__", "foo", "bar"], False, 4, 5, 20.),
-                          (PARTLY_EXCUSED_FILE_PATH, ["FooBar.__init__", "bar"], True, 2, 8, 75.)])
-def test_should_report_partial_coverage(file_path, missing, module_doc, missing_count, needed_count, coverage):
+@pytest.mark.parametrize(
+    "file_path,  missing, module_doc,missing_count, needed_count, coverage",
+    [
+        (PARTLY_DOCUMENTED_FILE_PATH, ["FooBar.__init__", "foo", "bar"], False, 4, 5, 20.0),
+        (PARTLY_EXCUSED_FILE_PATH, ["FooBar.__init__", "bar"], True, 2, 8, 75.0),
+    ],
+)
+def test_should_report_partial_coverage(
+    file_path, missing, module_doc, missing_count, needed_count, coverage
+):
     file_results, total_results = get_docstring_coverage([file_path])
     assert file_results == {
         file_path: {
@@ -67,7 +73,11 @@ def test_should_report_partial_coverage(file_path, missing, module_doc, missing_
             "empty": False,
         }
     }
-    assert total_results == {"missing_count": missing_count, "needed_count": needed_count, "coverage": coverage}
+    assert total_results == {
+        "missing_count": missing_count,
+        "needed_count": needed_count,
+        "coverage": coverage,
+    }
 
 
 def test_should_report_for_multiple_files():
@@ -126,15 +136,15 @@ def test_should_report_when_no_docs_in_a_file():
     ["expected"],
     [
         (
-                [
-                    '\nFile: "tests/sample_files/subdir_a/empty_file.py"',
-                    " - File is empty",
-                    " Needed: 0; Found: 0; Missing: 0; Coverage: 0.0%",
-                    "\n",
-                    "Overall statistics (1 files are empty):",
-                    "Needed: 0  -  Found: 0  -  Missing: 0",
-                    "Total coverage: 100.0%  -  Grade: " + GRADES[0][0],
-                ],
+            [
+                '\nFile: "tests/sample_files/subdir_a/empty_file.py"',
+                " - File is empty",
+                " Needed: 0; Found: 0; Missing: 0; Coverage: 0.0%",
+                "\n",
+                "Overall statistics (1 files are empty):",
+                "Needed: 0  -  Found: 0  -  Missing: 0",
+                "Total coverage: 100.0%  -  Grade: " + GRADES[0][0],
+            ],
         )
     ],
 )
@@ -149,65 +159,65 @@ def test_logging_empty_file(caplog, expected):
     ["expected", "verbose", "ignore_names"],
     [
         (
-                [
-                    '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
-                    " - No module docstring",
-                    " - No docstring for `foo`",
-                    " - No docstring for `bar`",
-                    " Needed: 4; Found: 1; Missing: 3; Coverage: 25.0%",
-                    "\n",
-                    "Overall statistics:",
-                    "Needed: 4  -  Found: 1  -  Missing: 3",
-                    "Total coverage: 25.0%  -  Grade: " + GRADES[6][0],
-                ],
-                3,
-                ([".*", "__.+__"],),
+            [
+                '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
+                " - No module docstring",
+                " - No docstring for `foo`",
+                " - No docstring for `bar`",
+                " Needed: 4; Found: 1; Missing: 3; Coverage: 25.0%",
+                "\n",
+                "Overall statistics:",
+                "Needed: 4  -  Found: 1  -  Missing: 3",
+                "Total coverage: 25.0%  -  Grade: " + GRADES[6][0],
+            ],
+            3,
+            ([".*", "__.+__"],),
         ),
         (
-                [
-                    '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
-                    " - No module docstring",
-                    " - No docstring for `FooBar.__init__`",
-                    " - No docstring for `foo`",
-                    " - No docstring for `bar`",
-                    " Needed: 5; Found: 1; Missing: 4; Coverage: 20.0%",
-                    "\n",
-                    "Overall statistics:",
-                    "Needed: 5  -  Found: 1  -  Missing: 4",
-                    "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
-                ],
-                3,
-                (),
+            [
+                '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
+                " - No module docstring",
+                " - No docstring for `FooBar.__init__`",
+                " - No docstring for `foo`",
+                " - No docstring for `bar`",
+                " Needed: 5; Found: 1; Missing: 4; Coverage: 20.0%",
+                "\n",
+                "Overall statistics:",
+                "Needed: 5  -  Found: 1  -  Missing: 4",
+                "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
+            ],
+            3,
+            (),
         ),
         (
-                [
-                    '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
-                    " Needed: 5; Found: 1; Missing: 4; Coverage: 20.0%",
-                    "\n",
-                    "Overall statistics:",
-                    "Needed: 5  -  Found: 1  -  Missing: 4",
-                    "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
-                ],
-                2,
-                (),
+            [
+                '\nFile: "tests/sample_files/subdir_a/partly_documented_file.py"',
+                " Needed: 5; Found: 1; Missing: 4; Coverage: 20.0%",
+                "\n",
+                "Overall statistics:",
+                "Needed: 5  -  Found: 1  -  Missing: 4",
+                "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
+            ],
+            2,
+            (),
         ),
         (
-                [
-                    "Overall statistics:",
-                    "Needed: 5  -  Found: 1  -  Missing: 4",
-                    "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
-                ],
-                1,
-                (),
+            [
+                "Overall statistics:",
+                "Needed: 5  -  Found: 1  -  Missing: 4",
+                "Total coverage: 20.0%  -  Grade: " + GRADES[7][0],
+            ],
+            1,
+            (),
         ),
         (
-                [
-                    "Overall statistics:",
-                    "Needed: 2  -  Found: 1  -  Missing: 1",
-                    "Total coverage: 50.0%  -  Grade: " + GRADES[5][0],
-                ],
-                1,
-                ([".*", ".*"],),
+            [
+                "Overall statistics:",
+                "Needed: 2  -  Found: 1  -  Missing: 1",
+                "Total coverage: 50.0%  -  Grade: " + GRADES[5][0],
+            ],
+            1,
+            ([".*", ".*"],),
         ),
     ],
 )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -6,9 +6,6 @@ import pytest
 from docstr_coverage import get_docstring_coverage
 from docstr_coverage.coverage import GRADES
 
-# TODO revert
-os.chdir("..")
-
 SAMPLES_DIRECTORY = os.path.join("tests", "sample_files", "subdir_a")
 EXCUSED_SAMPLES_DIRECTORY = os.path.join("tests", "excused_samples")
 EMPTY_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "empty_file.py")

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -53,7 +53,7 @@ def test_should_report_full_coverage(file_path, needed_count):
 
 
 @pytest.mark.parametrize(
-    "file_path,  missing, module_doc,missing_count, needed_count, coverage",
+    ["file_path", "missing", "module_doc", "missing_count", "needed_count", "coverage"],
     [
         (PARTLY_DOCUMENTED_FILE_PATH, ["FooBar.__init__", "foo", "bar"], False, 4, 5, 20.0),
         (PARTLY_EXCUSED_FILE_PATH, ["FooBar.__init__", "bar"], True, 2, 8, 75.0),

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -7,13 +7,14 @@ from docstr_coverage import get_docstring_coverage
 from docstr_coverage.coverage import GRADES
 
 SAMPLES_DIRECTORY = os.path.join("tests", "sample_files", "subdir_a")
-EXCUSED_SAMPLES_DIRECTORY = os.path.join("tests", "excused_samples")
 EMPTY_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "empty_file.py")
 DOCUMENTED_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "documented_file.py")
-FULLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "fully_excused.py")
-PARTLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "partially_excused.py")
 PARTLY_DOCUMENTED_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "partly_documented_file.py")
 SOME_CODE_NO_DOCS_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "some_code_no_docs.py")
+
+EXCUSED_SAMPLES_DIRECTORY = os.path.join("tests", "excused_samples")
+FULLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "fully_excused.py")
+PARTLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "partially_excused.py")
 
 SAMPLES_C_DIRECTORY = os.path.join("tests", "extra_samples")
 PRIVATE_NO_DOCS_PATH = os.path.join(SAMPLES_C_DIRECTORY, "private_undocumented.py")

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -14,6 +14,7 @@ EXCUSED_SAMPLES_DIRECTORY = os.path.join("tests", "excused_samples")
 EMPTY_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "empty_file.py")
 DOCUMENTED_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "documented_file.py")
 FULLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "fully_excused.py")
+PARTLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "partially_excused.py")
 PARTLY_DOCUMENTED_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "partly_documented_file.py")
 SOME_CODE_NO_DOCS_FILE_PATH = os.path.join(SAMPLES_DIRECTORY, "some_code_no_docs.py")
 
@@ -54,19 +55,22 @@ def test_should_report_full_coverage(file_path, needed_count):
     assert total_results == {"missing_count": 0, "needed_count": needed_count, "coverage": 100.0}
 
 
-def test_should_report_partial_coverage():
-    file_results, total_results = get_docstring_coverage([PARTLY_DOCUMENTED_FILE_PATH])
+@pytest.mark.parametrize("file_path,  missing, module_doc,missing_count, needed_count, coverage",
+                         [(PARTLY_DOCUMENTED_FILE_PATH, ["FooBar.__init__", "foo", "bar"], False, 4, 5, 20.),
+                          (PARTLY_EXCUSED_FILE_PATH, ["FooBar.__init__", "bar"], True, 2, 8, 75.)])
+def test_should_report_partial_coverage(file_path, missing, module_doc, missing_count, needed_count, coverage):
+    file_results, total_results = get_docstring_coverage([file_path])
     assert file_results == {
-        PARTLY_DOCUMENTED_FILE_PATH: {
-            "missing": ["FooBar.__init__", "foo", "bar"],
-            "module_doc": False,
-            "missing_count": 4,
-            "needed_count": 5,
-            "coverage": 20.0,
+        file_path: {
+            "missing": missing,
+            "module_doc": module_doc,
+            "missing_count": missing_count,
+            "needed_count": needed_count,
+            "coverage": coverage,
             "empty": False,
         }
     }
-    assert total_results == {"missing_count": 4, "needed_count": 5, "coverage": 20.0}
+    assert total_results == {"missing_count": missing_count, "needed_count": needed_count, "coverage": coverage}
 
 
 def test_should_report_for_multiple_files():

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -35,7 +35,7 @@ def test_should_report_for_an_empty_file():
 
 
 @pytest.mark.parametrize(
-    "file_path,needed_count", [(DOCUMENTED_FILE_PATH, 9), (FULLY_EXCUSED_FILE_PATH, 8)]
+    ["file_path", "needed_count"], [(DOCUMENTED_FILE_PATH, 9), (FULLY_EXCUSED_FILE_PATH, 8)]
 )
 def test_should_report_full_coverage(file_path, needed_count):
     file_results, total_results = get_docstring_coverage([file_path])


### PR DESCRIPTION
This provides the gentle workaround discussed in #28.

### Usage
See the small explanation in the README.md for details on how to use the new feature.

### External Impacts
I did not have to add any additional packages to the dependency tree. 
However, my implementation relies on the native `tokenize` module. This requires that every file is parsed twice (once for ast and once for tokenize). However, I do not think that this is a big problem - the whole thing is still very fast.

It might not be the most elegant solution - but it is one that allowed me to keep essentially all existing code untouched.

### How is it tested
Besides the unit tests which are all passing, I performed a test on a rather large library (~30 files in a hierarchical package architecture) on ubuntu 20.04 with python 3.8. I found no issues.
To this extent, let me note that the [dev deployment to pipy test](https://test.pypi.org/project/docstr-coverage/) is still online, in case someone wants to test without doing a local install.