### PR TITLE
Add import sorting check to workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,7 @@ jobs:
           pip install -e .[lint]
       - run: black . --check
       - run: flake8
+      - run: isort docstr_coverage tests --check-only --profile black
 
   test:
     runs-on: ubuntu-latest

--- a/docstr_coverage/badge.py
+++ b/docstr_coverage/badge.py
@@ -7,8 +7,8 @@ repository. Thank you to the authors for their fantastic work! Go give
 [coverage-badge](https://github.com/dbrgn/coverage-badge) a star!"""
 
 import os
-import pkg_resources
 
+import pkg_resources
 
 COLORS = {
     "brightgreen": "#4c1",

--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -1,10 +1,11 @@
 """This module is the CLI entry point for `docstr_coverage` in which CLI arguments are defined and
 passed on to other modules"""
-import click
 import os
 import re
 import sys
 from typing import List, Optional
+
+import click
 
 from docstr_coverage.badge import Badge
 from docstr_coverage.coverage import get_docstring_coverage

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -1,11 +1,12 @@
 """This repository is based on the work of Alexey "DataGreed" Strelkov,
 and James Harlow (see "THANKS.txt" for details)"""
 
-# TODO: If Python 2, ```from __future__ import print_function```
-from ast import parse
 import logging
 import os
 import re
+
+# TODO: If Python 2, ```from __future__ import print_function```
+from ast import parse
 from typing import List, Tuple
 
 from docstr_coverage.visitor import DocStringCoverageVisitor

--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -1,7 +1,7 @@
 """This module handles traversing abstract syntax trees to check for docstrings"""
 import re
 import tokenize
-from ast import NodeVisitor, get_docstring, FunctionDef, ClassDef, Module
+from ast import ClassDef, FunctionDef, Module, NodeVisitor, get_docstring
 
 ACCEPTED_EXCUSE_PATTERNS = (
     re.compile(r"#\s*docstr-coverage\s*:\s*inherit(ed)?\s*"),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=["docstr_coverage"],
     install_requires=["click"],
     extras_require={
-        "lint": ["flake8==3.8.2", "black==19.10b0"],
+        "lint": ["flake8==3.8.2", "black==19.10b0", "isort==5.6.4"],
         "test": ["pytest==5.4.2", "pytest-mock"],
     },
     include_package_data=True,

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,9 +1,9 @@
 """Tests for :mod:`docstr_coverage.badge`"""
 import os
+
 import pytest
 
 from docstr_coverage.badge import Badge
-
 
 CWD = os.path.abspath(os.path.dirname(__file__))
 SAMPLE_BADGE_DIR = os.path.join(CWD, "sample_files", "badges")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,10 @@
 """Tests for :mod:`docstr_coverage.cli`"""
-from click.testing import CliRunner
 import os
-import pytest
 import re
 from typing import List, Optional
+
+import pytest
+from click.testing import CliRunner
 
 from docstr_coverage.cli import (
     collect_filepaths,


### PR DESCRIPTION
Given our recent discussion, I thought we may want to add a check which controls the order of the imports to the CI. 

Feel free to close the PR if you prefer manual checks.

p.s. imports can be automatically ordered using `isort --profile black docstr_coverage tests`