### PR TITLE
Use click counting for verbose output in CLI

### DIFF
--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -152,14 +152,10 @@ def parse_ignore_patterns_from_dict(ignore_patterns_dict) -> tuple:
 
 @click.command()
 @click.option(
-    # TODO: Use counting instead: https://click.palletsprojects.com/en/7.x/options/#counting
     "-v",
     "--verbose",
-    type=click.Choice([0, 1, 2, 3, "0", "1", "2", "3"]),
-    default="3",
-    help="Verbosity level",
-    show_default=True,
-    callback=lambda _ctx, _param, value: int(value),
+    count=True,
+    help="Verbosity level, up to 3 -v's",
 )
 @click.option(
     "-e",


### PR DESCRIPTION
Closes #51

This PR still needs one more thing - typically more `-v`'s means more verbose. Maybe instead of a verbose option, it would be better to switch this to a "quiet" option