### PR TITLE
Fix --help / -h

### DIFF
--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -155,7 +155,7 @@ def parse_ignore_patterns_from_dict(ignore_patterns_dict) -> tuple:
     # TODO: Use counting instead: https://click.palletsprojects.com/en/7.x/options/#counting
     "-v",
     "--verbose",
-    type=click.Choice([0, 1, 2, 3, "0", "1", "2", "3"]),
+    type=click.Choice(["0", "1", "2", "3"]),
     default="3",
     help="Verbosity level",
     show_default=True,

--- a/docstr_coverage/config_file.py
+++ b/docstr_coverage/config_file.py
@@ -35,8 +35,8 @@ def set_config_defaults(ctx, param, value):
         )
         _extract_non_default_list(config_data, ctx, "ignore_patterns", lambda x: x)
         # TODO This can be removed as part PR #52 (verbose counting). Until then, this is for backwards compatibility
-        if 'verbose' in config_data:
-            config_data['verbose'] = str(config_data['verbose'])
+        if "verbose" in config_data:
+            config_data["verbose"] = str(config_data["verbose"])
         ctx.default_map = config_data
 
     return value

--- a/docstr_coverage/config_file.py
+++ b/docstr_coverage/config_file.py
@@ -22,7 +22,7 @@ def set_config_defaults(ctx, param, value):
     -------
     String
         Path to the configuration file"""
-    if (value is not None) and os.path.exists(value):
+    if value is not None and os.path.exists(value):
         with open(value) as f:
             config_data = yaml.safe_load(f) or {}
             ctx.params["config_file"] = value
@@ -34,6 +34,9 @@ def set_config_defaults(ctx, param, value):
             lambda config_paths: tuple([os.path.realpath(path) for path in config_paths]),
         )
         _extract_non_default_list(config_data, ctx, "ignore_patterns", lambda x: x)
+        # TODO This can be removed as part PR #52 (verbose counting). Until then, this is for backwards compatibility
+        if 'verbose' in config_data:
+            config_data['verbose'] = str(config_data['verbose'])
         ctx.default_map = config_data
 
     return value

--- a/docstr_coverage/config_file.py
+++ b/docstr_coverage/config_file.py
@@ -35,7 +35,8 @@ def set_config_defaults(ctx, param, value):
         )
         _extract_non_default_list(config_data, ctx, "ignore_patterns", lambda x: x)
         # TODO This can be removed as part PR #52 (verbose counting).
-        #       Until then, this is for backwards compatibility
+        #       Until then, this is for compatibility with docs
+        #       which require verbose in config-file to be an int
         if "verbose" in config_data:
             config_data["verbose"] = str(config_data["verbose"])
         ctx.default_map = config_data

--- a/docstr_coverage/config_file.py
+++ b/docstr_coverage/config_file.py
@@ -34,7 +34,8 @@ def set_config_defaults(ctx, param, value):
             lambda config_paths: tuple([os.path.realpath(path) for path in config_paths]),
         )
         _extract_non_default_list(config_data, ctx, "ignore_patterns", lambda x: x)
-        # TODO This can be removed as part PR #52 (verbose counting). Until then, this is for backwards compatibility
+        # TODO This can be removed as part PR #52 (verbose counting).
+        #       Until then, this is for backwards compatibility
         if "verbose" in config_data:
             config_data["verbose"] = str(config_data["verbose"])
         ctx.default_map = config_data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,7 +239,7 @@ def test_parse_ignore_names_file(path: str, expected: tuple):
 )
 @pytest.mark.parametrize("verbose_flag", [["-v", "0"], ["-v", "1"], ["-v", "2"], ["-v", "3"]])
 def test_percentage_only(
-    paths: List[str], expected_output: str, verbose_flag: List[str], runner: CliRunner
+        paths: List[str], expected_output: str, verbose_flag: List[str], runner: CliRunner
 ):
     """Test that using the `--percentage-only` CLI option works correctly
 
@@ -292,13 +292,13 @@ def test_percentage_only(
 )
 @pytest.mark.usefixtures("cd_tests_dir_fixture")
 def test_cli_collect_filepaths(
-    paths: List[str],
-    follow_links_flag: List[str],
-    follow_links_value: bool,
-    exclude_flag: List[str],
-    exclude_value: Optional[str],
-    runner: CliRunner,
-    mocker,
+        paths: List[str],
+        follow_links_flag: List[str],
+        follow_links_value: bool,
+        exclude_flag: List[str],
+        exclude_value: Optional[str],
+        runner: CliRunner,
+        mocker,
 ):
     """Test that CLI inputs are correctly interpreted and passed along to
     :func:`docstr_coverage.cli.collect_filepaths`
@@ -541,8 +541,8 @@ def test_deprecations(paths, deprecated_option, runner: CliRunner):
 @pytest.mark.parametrize(
     ["help_flag"],
     [
-        pytest.param(["--help"]),
-        pytest.param(["--h"])
+        pytest.param(["--help"], id="long: --help"),
+        pytest.param(["-h"], id="short: -h")
     ],
 )
 def test_help_smoke(help_flag: str, runner: CliRunner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -556,4 +556,5 @@ def test_help_smoke(help_flag: str, runner: CliRunner):
         Click utility to invoke command line scripts"""
     run_result = runner.invoke(execute, help_flag)
     assert run_result.exit_code == 0
-    # TODO Assert help string
+    assert isinstance(run_result.stdout, str)
+    assert "Measure docstring coverage for" in run_result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -536,3 +536,24 @@ def test_deprecations(paths, deprecated_option, runner: CliRunner):
     assert run_result.stdout.startswith(
         "Using deprecated {}".format(deprecated_option[0].split("=")[0])
     )
+
+
+@pytest.mark.parametrize(
+    ["help_flag"],
+    [
+        pytest.param(["--help"]),
+        pytest.param(["--h"])
+    ],
+)
+def test_help_smoke(help_flag: str, runner: CliRunner):
+    """Smoke test which ensures that help is printed with exit code 0
+
+    Parameters
+    ----------
+    help_flag:
+        The (short or long) help path argument
+    runner: CliRunner
+        Click utility to invoke command line scripts"""
+    run_result = runner.invoke(execute, help_flag)
+    assert run_result.exit_code == 0
+    # TODO Assert help string

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,7 +239,7 @@ def test_parse_ignore_names_file(path: str, expected: tuple):
 )
 @pytest.mark.parametrize("verbose_flag", [["-v", "0"], ["-v", "1"], ["-v", "2"], ["-v", "3"]])
 def test_percentage_only(
-        paths: List[str], expected_output: str, verbose_flag: List[str], runner: CliRunner
+    paths: List[str], expected_output: str, verbose_flag: List[str], runner: CliRunner
 ):
     """Test that using the `--percentage-only` CLI option works correctly
 
@@ -292,13 +292,13 @@ def test_percentage_only(
 )
 @pytest.mark.usefixtures("cd_tests_dir_fixture")
 def test_cli_collect_filepaths(
-        paths: List[str],
-        follow_links_flag: List[str],
-        follow_links_value: bool,
-        exclude_flag: List[str],
-        exclude_value: Optional[str],
-        runner: CliRunner,
-        mocker,
+    paths: List[str],
+    follow_links_flag: List[str],
+    follow_links_value: bool,
+    exclude_flag: List[str],
+    exclude_value: Optional[str],
+    runner: CliRunner,
+    mocker,
 ):
     """Test that CLI inputs are correctly interpreted and passed along to
     :func:`docstr_coverage.cli.collect_filepaths`
@@ -540,10 +540,7 @@ def test_deprecations(paths, deprecated_option, runner: CliRunner):
 
 @pytest.mark.parametrize(
     ["help_flag"],
-    [
-        pytest.param(["--help"], id="long: --help"),
-        pytest.param(["-h"], id="short: -h")
-    ],
+    [pytest.param(["--help"], id="long: --help"), pytest.param(["-h"], id="short: -h")],
 )
 def test_help_smoke(help_flag: str, runner: CliRunner):
     """Smoke test which ensures that help is printed with exit code 0


### PR DESCRIPTION
This is a quick-fix to allow to use `-h` and `--help` again, before introducing the counting version discussed in #52. Thus, is fixes #51

#### About the fix: 

1. The click.Choice docs states that `(...) All of these values have to be strings.`, thus I removed the ints (as also suggested by @cthoyt)
2. To keep compatibility with the config description (which requires ints), the config parser is adapted, to cast int-verbosity to str-verbosity
3. Smoke tests for `-h` and `--help` are added to ensure we do not stumble over smth. like this again

#### Why not wait for #52?

The counting discussed in #51 and #52 is important and also IMO the way to go. But design and implementation take time- further discussion might still be required. In the meantime, our users should be able to use the help. This PR would allow us to release 2.0.1 minor version, allowing the users to use help while we work on the optimal solution...

Also, while #52 will probably be a breaking change, this PR should be compatible with the docs.

This also goes in line with the proposition [here](https://github.com/HunterMcGushion/docstr_coverage/pull/52#issuecomment-765602388)