### PR TITLE
Extract method, provide simplified signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,10 @@ class FooBarChild(FooBar):
 You can also use `docstr-coverage` as a part of your project by importing it thusly:
 
 ```python
-from docstr_coverage import get_docstring_coverage
-my_coverage = get_docstring_coverage(['some_dir/file_0.py', 'some_dir/file_1.py'])
+from docstr_coverage import analyze
+coverage_report = analyze(['some_dir/file_0.py', 'some_dir/file_1.py'])
+coverage = coverage_report.count_aggregate().coverage()
 ```
-
-##### Arguments
-
-- Required arg: `filenames` \<list of string filenames\>
-- Optional kwargs: `skip_magic` \<bool\>, `skip_file_docstring` \<bool\>, `skip_private` \<bool\>, `verbose` \<int (0-3)\> \* For more info on `get_docstring_coverage` and its parameters, please see its [documentation](https://docstr-coverage.readthedocs.io/en/latest/api_essentials.html#get-docstring-coverage)
-
-##### Results
-
-`get_docstring_coverage` returns two dicts: 1) stats for each file, and 2) total stats.
-For more info, please see the `get_docstring_coverage` [documentation](https://docstr-coverage.readthedocs.io/en/latest/api_essentials.html#get-docstring-coverage)
 
 ## Why Should I Use It
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,15 @@ class FooBarChild(FooBar):
 
 #### Package in Your Project
 
-You can also use `docstr-coverage` as a part of your project by importing it thusly:
+You can also use `docstr-coverage` as a part of your project by importing it thusly.
+It will supply you with overall and per-file coverages:
 
+```python
+from docstr_coverage import get_docstring_coverage
+my_coverage = get_docstring_coverage(['some_dir/file_0.py', 'some_dir/file_1.py'])
+```
+
+If you want more fine grained information, try the experimental `docstr_coverage.analyze()`
 ```python
 from docstr_coverage import analyze
 coverage_report = analyze(['some_dir/file_0.py', 'some_dir/file_1.py'])

--- a/docstr_coverage/__init__.py
+++ b/docstr_coverage/__init__.py
@@ -1,8 +1,6 @@
 ##################################################
 # Set __all__
 ##################################################
-from .coverage import get_docstring_coverage
+from .coverage import analyze, get_docstring_coverage
 
-__all__ = [
-    "get_docstring_coverage",
-]
+__all__ = ["analyze", "get_docstring_coverage"]

--- a/docstr_coverage/__init__.py
+++ b/docstr_coverage/__init__.py
@@ -2,5 +2,17 @@
 # Set __all__
 ##################################################
 from .coverage import analyze, get_docstring_coverage
+from .ignore_config import IgnoreConfig
+from .printers import LegacyPrinter
+from .result_collection import ResultCollection, AggregatedCount, ExpectedDocstring, FileCount
 
-__all__ = ["analyze", "get_docstring_coverage"]
+__all__ = [
+    "analyze",
+    "get_docstring_coverage",
+    "IgnoreConfig",
+    "LegacyPrinter",
+    "ResultCollection",
+    "AggregatedCount",
+    "ExpectedDocstring",
+    "FileCount",
+]

--- a/docstr_coverage/__init__.py
+++ b/docstr_coverage/__init__.py
@@ -4,7 +4,12 @@
 from .coverage import analyze, get_docstring_coverage
 from .ignore_config import IgnoreConfig
 from .printers import LegacyPrinter
-from .result_collection import ResultCollection, AggregatedCount, ExpectedDocstring, FileCount
+from .result_collection import (
+    AggregatedCount,
+    ExpectedDocstring,
+    FileCount,
+    ResultCollection,
+)
 
 __all__ = [
     "analyze",

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -1,11 +1,13 @@
-"""This repository is based on the work of Alexey "DataGreed" Strelkov,
-and James Harlow (see "THANKS.txt" for details)"""
+"""This module is the central module for coverage collection,
+responsible for filewalking"""
 
 import os
 import re
+import warnings
 from ast import parse
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
+from docstr_coverage.ignore_config import IgnoreConfig
 from docstr_coverage.printers import LegacyPrinter
 from docstr_coverage.result_collection import File, FileStatus, ResultCollection
 from docstr_coverage.visitor import DocStringCoverageVisitor
@@ -25,11 +27,7 @@ def do_ignore_node(filename: str, base_name: str, node_name: str, ignore_names: 
         the case of method names, `node_name` will be only the method's name, while `base_name` will
         be of the form "<class_name>."
     ignore_names: Tuple[List[str], ...]
-        Patterns to ignore when checking documentation. Each list in `ignore_names` defines a
-        different pattern to be ignored. The first element in each list is the regular expression
-        for matching filenames. All remaining arguments in each list are regexes for matching names
-        of functions/classes. A node is ignored if it matches the filename regex and at least one
-        of the remaining regexes
+        Ignore names. See `IgnoreConfig`
 
     Returns
     -------
@@ -63,6 +61,71 @@ def do_ignore_node(filename: str, base_name: str, node_name: str, ignore_names: 
     return False
 
 
+def analyze_docstrings(
+    file_result: File,
+    base: str,
+    node: Tuple[str, bool, List],
+    filename,
+    ignore_config: IgnoreConfig,
+):
+    """Track the existence of a docstring for `node`, and accumulate stats regarding
+    expected and encountered docstrings for `node` and its children (if any).
+
+    Parameters
+    ----------
+    file_result: File
+        The result-collection file instance on which the docstring presence is recorded.
+    base: String
+        The name of this node's parent node
+    node: Tuple triple of (String, Boolean, List)
+        Information describing a node. `node[0]` is the node's name.
+        `node[1]` is True if the node was properly documented,
+        else False. `node[3]` is a list containing the node's children
+        as triples of the same form (if it had any)
+    filename: String
+        String containing a name of file.
+    ignore_config: IgnoreConfig
+        Information about which docstrings are to be ignored."""
+
+    name, has_doc, child_nodes = node
+
+    # ------------------
+    # Check Current Node
+    # ------------------
+
+    # Check for ignore status
+    ignore_reason = None
+    if ignore_config.skip_init and name == "__init__":
+        ignore_reason = "skip-init set to True"
+    elif (
+        ignore_config.skip_magic
+        and name.startswith("__")
+        and name.endswith("__")
+        and name != "__init__"
+    ):
+        ignore_reason = "skip-magic set to True"
+    elif ignore_config.skip_class_def and "_" not in name and (name[0] == name[0].upper()):
+        ignore_reason = "skip-class-def set to True"
+    elif ignore_config.skip_private and name.startswith("_") and not name.startswith("__"):
+        ignore_reason = "skip-private set to True"
+    elif ignore_config.ignore_names and do_ignore_node(
+        filename, base, name, ignore_config.ignore_names
+    ):
+        ignore_reason = "matching ignore pattern"
+
+    # Set Result
+    node_identifier = str(base) + str(name)
+    file_result.collect_docstring(
+        identifier=node_identifier, has_docstring=has_doc, ignore_reason=ignore_reason
+    )
+
+    # -----------------
+    # Check Child Nodes
+    # -----------------
+    for _symbol in child_nodes:
+        analyze_docstrings(file_result, "%s." % name, _symbol, filename, ignore_config)
+
+
 def get_docstring_coverage(
     filenames: list,
     skip_magic: bool = False,
@@ -72,122 +135,58 @@ def get_docstring_coverage(
     skip_private: bool = False,
     verbose: int = 0,
     ignore_names: Tuple[List[str], ...] = (),
-):
+) -> Tuple[Dict, Dict]:
+    """
+    ***DEPRECATED***
+    This used to be the primary way to access docstr-coverage as software library.
+    It is now replaced by the function `analyze`, which provides
+    a slimmer interface and a more informative return value.
+
+    For backwards compatibility of the return value with existing code,
+    call `analyze(...).to_legacy()`."""
+    warnings.warn(
+        "get_docstring_coverage is deprecated." "See function docstring for details.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    ignore_config = IgnoreConfig(
+        skip_magic=skip_magic,
+        skip_file_docstring=skip_file_docstring,
+        skip_init=skip_init,
+        skip_class_def=skip_class_def,
+        skip_private=skip_private,
+        ignore_names=ignore_names,
+    )
+    results = analyze(filenames, ignore_config)
+    LegacyPrinter(verbosity=verbose, ignore_config=ignore_config).print(results)
+    return results.to_legacy()
+
+
+def analyze(filenames: list, ignore_config: IgnoreConfig = IgnoreConfig()) -> ResultCollection:
     """Checks contents of `filenames` for missing docstrings, and produces a report
-    detailing docstring status.
-
-    Parameters
-    ----------
-    filenames: List
-        List of filename strings that are absolute or relative paths
-    skip_magic: Boolean, default=False
-        If True, skips all magic methods (double-underscore-prefixed),
-        except '__init__' and does not include them in the report
-    skip_file_docstring: Boolean, default=False
-        If True, skips check for a module-level docstring
-    skip_init: Boolean, default=False
-        If True, skips methods named '__init__' and does not include
-        them in the report
-    skip_class_def: Boolean, default=False
-        If True, skips class definitions and does not include them in the report.
-        If this is True, the class's methods will still be checked
-    skip_private: Boolean, default=False
-        If True, skips function definitions beginning with a single underscore and does
-        not include them in the report.
-    verbose: Int in [0, 1, 2, 3], default=0
-        0) No printing.
-        1) Print total stats only.
-        2) Print stats for all files.
-        3) Print missing docstrings for all files.
-    ignore_names: Tuple[List[str], ...], default=()
-        Patterns to ignore when checking documentation. Each list in `ignore_names` defines a
-        different pattern to be ignored. The first element in each list is the regular expression
-        for matching filenames. All remaining arguments in each list are regexes for matching names
-        of functions/classes. A node is ignored if it matches the filename regex and at least one
-        of the remaining regexes
-
-    Returns
-    -------
-    Dict
-        Links filename keys to a dict of stats for that filename. Example:
-
-        >>> {
-        ...     '<filename>': {
-        ...         'missing': ['<method_or_class_name>', '...'],
-        ...         'module_doc': '<Boolean>',
-        ...         'missing_count': '<missing_count int>',
-        ...         'needed_count': '<needed_docstrings_count int>',
-        ...         'coverage': '<percent_of_coverage float>',
-        ...         'empty': '<Boolean>'
-        ...     }, ...
-        ... }
-    Dict
-        Total summary stats for all files analyzed. Example:
-
-        >>> {
-        ...     'missing_count': '<total_missing_count int>',
-        ...     'needed_count': '<total_needed_docstrings_count int>',
-        ...     'coverage': '<total_percent_of_coverage float>'
-        ... }"""
-
-    # TODO: Move :func:`analyze_docstrings` to be a normal function
-    #       outside of :func:`get_docstring_coverage`
-    def analyze_docstrings(result_collection: File, base, node, filename, ignore_names=()):
-        """Track the existence of a docstring for `node`, and accumulate stats regarding
-        expected and encountered docstrings for `node` and its children (if any).
+        detailing docstring status.
 
         Parameters
         ----------
-        result_collection: File
-            The result-collection file instance on which the docstring presence is recorded.
-        base: String
-            The name of this node's parent node
-        node: Tuple triple of (String, Boolean, List)
-            Information describing a node. `node[0]` is the node's name.
-            `node[1]` is True if the node was properly documented,
-            else False. `node[3]` is a list containing the node's children
-            as triples of the same form (if it had any)
-        filename: String
-            String containing a name of file.
-        ignore_names: tuple of lists ([String, String, [String...]]) where the first
-            element is the regular expression for matching filenames. All remaining
-            arguments are regexes for matching names of functions/classes to be
-            excluded from checking for documentation. It will be excluded if and
-            only if the first and at least one of the remaining regexes hits a match."""
+        filenames: List
+            List of filename strings that are absolute or relative paths
 
-        name, has_doc, child_nodes = node
+        ignore_config: IgnoreConfig
+            Information about which docstrings are to be ignored.
 
-        #################### Check Current Node ####################
-
-        ### Check for ignore status
-        ignore_reason = None
-        if skip_init and name == "__init__":
-            ignore_reason = "skip-init set to True"
-        elif skip_magic and name.startswith("__") and name.endswith("__") and name != "__init__":
-            ignore_reason = "skip-magic set to True"
-        elif skip_class_def and "_" not in name and (name[0] == name[0].upper()):
-            ignore_reason = "skip-class-def set to True"
-        elif skip_private and name.startswith("_") and not name.startswith("__"):
-            ignore_reason = "skip-private set to True"
-        elif ignore_names and do_ignore_node(filename, base, name, ignore_names):
-            ignore_reason = "matching ignore pattern"
-
-        ### Set Result
-        node_identifier = str(base) + str(name)
-        result_collection.collect_docstring(
-            identifier=node_identifier, has_docstring=has_doc, ignore_reason=ignore_reason
-        )
-
-        #################### Check Child Nodes ####################
-        for _symbol in child_nodes:
-            analyze_docstrings(result_collection, "%s." % name, _symbol, filename, ignore_names)
+        Returns
+        -------
+        ResultCollection:
+            The collected information about docstring presence."""
 
     results = ResultCollection()
 
     for filename in filenames:
         file_result = results.get_file(file_path=filename)
 
-        #################### Read and Parse Source ####################
+        # ---------------------
+        # Read and Parse Source
+        # ---------------------
         with open(filename, "r", encoding="utf-8") as f:
             source_tree = f.read()
 
@@ -195,10 +194,13 @@ def get_docstring_coverage(
         doc_visitor.visit(parse(source_tree))
         _tree = doc_visitor.tree[0]
 
-        #################### Process Results ####################
+        # ---------------
+        # Process Results
+        # ---------------
+
         # _tree contains [<module docstring>, <is_empty: bool>, <symbols: classes and funcs>]
         if (not _tree[0]) and (not _tree[1]):
-            if not skip_file_docstring:
+            if not ignore_config.skip_file_docstring:
                 file_result.collect_module_docstring(has_docstring=False)
             else:
                 file_result.collect_module_docstring(
@@ -211,15 +213,6 @@ def get_docstring_coverage(
 
         # Recursively traverse through functions and classes
         for symbol in _tree[-1]:
-            analyze_docstrings(file_result, "", symbol, filename, ignore_names)
+            analyze_docstrings(file_result, "", symbol, filename, ignore_config)
 
-    LegacyPrinter(
-        verbosity=verbose,
-        skip_magic=skip_magic,
-        skip_file_docstring=skip_file_docstring,
-        skip_init=skip_init,
-        skip_class_def=skip_class_def,
-        skip_private=skip_private,
-    ).print(results)
-
-    return results.to_legacy()
+    return results

--- a/docstr_coverage/ignore_config.py
+++ b/docstr_coverage/ignore_config.py
@@ -1,0 +1,61 @@
+"""Module containing a single utility data class: IgnoreConfig"""
+from typing import List, Tuple
+
+
+class IgnoreConfig:
+    """An immutable data class, storing information about which types of
+    docstrings should be ignored when aggregating coverage."""
+
+    def __init__(
+        self,
+        skip_magic: bool = False,
+        skip_file_docstring: bool = False,
+        skip_init: bool = False,
+        skip_class_def: bool = False,
+        skip_private: bool = False,
+        ignore_names: Tuple[List[str], ...] = (),
+    ):
+        self._skip_magic = skip_magic
+        self._skip_file_docstring = skip_file_docstring
+        self._skip_init = skip_init
+        self._skip_class_def = skip_class_def
+        self._skip_private = skip_private
+        self._ignore_names = ignore_names
+
+    @property
+    def skip_magic(self):
+        """If True, skip all magic methods (double-underscore-prefixed),
+            except '__init__' and does not include them in the report."""
+        return self._skip_magic
+
+    @property
+    def skip_file_docstring(self):
+        """If True, skip check for a module-level docstring."""
+        return self._skip_file_docstring
+
+    @property
+    def skip_init(self):
+        """If True, skip methods named '__init__' and does not include
+            them in the report."""
+        return self._skip_init
+
+    @property
+    def skip_class_def(self):
+        """If True, skip class definitions and does not include them in the report.
+            If this is True, the class's methods will still be checked."""
+        return self._skip_class_def
+
+    @property
+    def skip_private(self):
+        """If True, skip function definitions beginning with a
+        single underscore and does not include them in the report."""
+        return self._skip_private
+
+    @property
+    def ignore_names(self):
+        """Patterns to ignore when checking documentation. Each list in `ignore_names` defines a
+        different pattern to be ignored. The first element in each list is the regular expression
+        for matching filenames. All remaining arguments in each list are regexes for matching names
+        of functions/classes. A node is ignored if it matches the filename regex and at least one
+        of the remaining regexes"""
+        return self._ignore_names

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -2,6 +2,7 @@
 Currently, this module is in BETA and its interface may change in future versions."""
 import logging
 
+from docstr_coverage.ignore_config import IgnoreConfig
 from docstr_coverage.result_collection import FileStatus
 
 _GRADES = (
@@ -38,15 +39,9 @@ class LegacyPrinter:
     will be extracted. Thus, coding against the current interface will require refactorings with
     future versions of docstr-coverage."""
 
-    def __init__(
-        self, verbosity, skip_magic, skip_file_docstring, skip_init, skip_class_def, skip_private,
-    ):
+    def __init__(self, verbosity: int, ignore_config: IgnoreConfig = IgnoreConfig()):
         self.verbosity = verbosity
-        self.skip_magic = skip_magic
-        self.skip_file_docstring = skip_file_docstring
-        self.skip_init = skip_init
-        self.skip_class_def = skip_class_def
-        self.skip_private = skip_private
+        self.ignore_config = ignore_config
 
     def print(self, results):
         """Prints a provided set of results to stdout.
@@ -105,15 +100,15 @@ class LegacyPrinter:
         postfix = ""
         if count.num_empty_files > 0:
             postfix = " (%s files are empty)" % count.num_empty_files
-        if self.skip_magic:
+        if self.ignore_config.skip_magic:
             postfix += " (skipped all non-init magic methods)"
-        if self.skip_file_docstring:
+        if self.ignore_config.skip_file_docstring:
             postfix += " (skipped file-level docstrings)"
-        if self.skip_init:
+        if self.ignore_config.skip_init:
             postfix += " (skipped __init__ methods)"
-        if self.skip_class_def:
+        if self.ignore_config.skip_class_def:
             postfix += " (skipped class definitions)"
-        if self.skip_private:
+        if self.ignore_config.skip_private:
             postfix += " (skipped private methods)"
 
         if count.num_files > 1:
@@ -127,7 +122,7 @@ class LegacyPrinter:
             ),
         )
 
-        #################### Calculate Total Grade ####################
+        # Calculate Total Grade
         grade = next(
             message for message, grade_threshold in _GRADES if grade_threshold <= count.coverage()
         )

--- a/docstr_coverage/result_collection.py
+++ b/docstr_coverage/result_collection.py
@@ -58,7 +58,34 @@ class ResultCollection:
 
     def to_legacy(self):
         """Converts the information in this `ResultCollection` into the less expressive dictionary
-        of counts used since the early versions of docstr-coverage."""
+        of counts used since the early versions of docstr-coverage.
+
+        Returns
+        --------
+        Dict
+            Links filename keys to a dict of stats for that filename. Example:
+
+            >>> {
+            ...     '<filename>': {
+            ...         'missing': ['<method_or_class_name>', '...'],
+            ...         'module_doc': '<Boolean>',
+            ...         'missing_count': '<missing_count int>',
+            ...         'needed_count': '<needed_docstrings_count int>',
+            ...         'coverage': '<percent_of_coverage float>',
+            ...         'empty': '<Boolean>'
+            ...     }, ...
+            ... }
+        Dict
+            Total summary stats for all files analyzed. Example:
+
+            >>> {
+            ...     'missing_count': '<total_missing_count int>',
+            ...     'needed_count': '<total_needed_docstrings_count int>',
+            ...     'coverage': '<total_percent_of_coverage float>'
+            ... }
+
+        """
+
         file_results = dict()
         for file_path, file in self.files():
             missing_list = [


### PR DESCRIPTION
This is the second refactoring commit, announced in #66, containing all the changes that would not directly belong in #66.

It contains:
- The very old TODO to extract the inner function of `get_docstring_coverage` is now resolved
- Exports a new `analyze` function, with the new, slim interface, deprecating `get_docstring_coverage`. This now allows to take advantage of the new `result_collection` class created in #66.
- Other super minor changes (typos and stuff)

Should be fully backward compatible.

It's a lot of changed loc, but this is mostly due to the extraction of a bunch of method parameters we used all over the place into a proper config class and the above-mentioned extraction on the inner function. Thus, I hope the review is not too much work ;-)