### PR TITLE
`docstr_coverage` => `docstr-coverage`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ MAJOR, MINOR, MICRO = 2, 0, 1
 __VERSION__ = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 
 setup(
-    name="docstr_coverage",
+    name="docstr-coverage",
     version=__VERSION__,
     description=(
         "Utility for examining python source files to ensure proper documentation. "


### PR DESCRIPTION
Reasons:
----------

(1) "Python packages should also have short, all-lowercase names, although the use of underscores is discouraged" ([source](https://www.python.org/dev/peps/pep-0008/#package-and-module-names))
(2) "Pip replaces underscores with dashes" ([link](https://pybuilder.io/documentation/publishing-plugins#:~:text=Pip%20replaces%20underscores%20with%20dashes,a%20syntax%20error%20at%20import.)), so there should not be a compatibility issue.
(3) Currently, github does not recognize the 'used-by' repositories; I assume this is due to this naming: It's based on the `setup.py` parsing. ([source](https://docs.github.com/en/code-security/supply-chain-security/about-the-dependency-graph#supported-package-ecosystems))
(4) Our readme and docs are using `-` since long.