### PR TITLE
chore(): added pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: docstr-coverage
+  name: docstr-coverage
+  entry: docstr-coverage
+  require_serial: true
+  language: python
+  language_version: python3
+  types_or: [cython, pyi, python]
+  minimum_pre_commit_version: "2.9.0"
+  always_run: true

--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ class FooBarChild(FooBar):
 
 #### Pre-commit hook
 
-Using `docstr-coverage` as a pre-commit hook is the preferred configuration method.
-
 You can use `docstr-coverage` as a pre-commit hook by adding the following to your .`.pre-commit-config.yaml` file:
+
+To pass arguments to `docstr-coverage`, add a `.docstr.yaml` config (which is automatically picked up).
+ This is preferrable over [pre-commit args](https://pre-commit.com/#config-args), 
+ as it facilitates the use of the same config in ci / pre-commit and manual runs.
 
 ```yaml
 - repo: https://github.com/HunterMcGushion/docstr_coverage
-  rev: v2.0.2
+  rev: <most recent docstr-coverage release or commit sha>
   hooks:
     - id: docstr-coverage
 ```

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ class FooBarChild(FooBar):
 
 #### Pre-commit hook
 
-You can use `docstr-coverage` as a pre-commit hook by adding the following to your .`.pre-commit-config.yaml` file:
+You can use `docstr-coverage` as a pre-commit hook by adding the following to your `.pre-commit-config.yaml` file:
 
 To pass arguments to `docstr-coverage`, add a `.docstr.yaml` config (which is automatically picked up).
  This is preferrable over [pre-commit args](https://pre-commit.com/#config-args), 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ class FooBarChild(FooBar):
         pass
 ```
 
+#### Pre-commit hook
+
+You can use `docstr-coverage` as a pre-commit hook like so:
+```yaml
+  - repo: https://github.com/HunterMcGushion/docstr_coverage
+    rev: v2.0.2
+    hooks:
+      - id: docstr-coverage
+```
+
 #### Package in Your Project
 
 You can also use `docstr-coverage` as a part of your project by importing it thusly:

--- a/README.md
+++ b/README.md
@@ -172,12 +172,15 @@ class FooBarChild(FooBar):
 
 #### Pre-commit hook
 
-You can use `docstr-coverage` as a pre-commit hook like so:
+Using `docstr-coverage` as a pre-commit hook is the preferred configuration method.
+
+You can use `docstr-coverage` as a pre-commit hook by adding the following to your .`.pre-commit-config.yaml` file:
+
 ```yaml
-  - repo: https://github.com/HunterMcGushion/docstr_coverage
-    rev: v2.0.2
-    hooks:
-      - id: docstr-coverage
+- repo: https://github.com/HunterMcGushion/docstr_coverage
+  rev: v2.0.2
+  hooks:
+    - id: docstr-coverage
 ```
 
 #### Package in Your Project


### PR DESCRIPTION
This adds support for using `docstr-coverage`  in a repository as a `pre-commit` hook.