### PR TITLE
Remove wrong assertion

### DIFF
--- a/docstr_coverage/visitor.py
+++ b/docstr_coverage/visitor.py
@@ -75,10 +75,6 @@ class DocStringCoverageVisitor(NodeVisitor):
         """Iterates through the tokenize tokens above the passed node to evaluate whether a
         doc-missing excuse has been placed (right) above this nodes begin"""
         node_start = node.lineno
-        assert node_start < len(self.tokens), (
-            "An unexpected context occurred during parsing of {} "
-            "It seems not all file lines were tokenized for comment checking."
-        ).format(self.filename)
 
         # Find the index of first token which starts at the same line as the node
         token_index = -1

--- a/tests/individual_samples/long_doc.py
+++ b/tests/individual_samples/long_doc.py
@@ -1,0 +1,23 @@
+"""
+this is a very long docstring
+
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+this is a very long docstring
+"""
+
+
+class A:
+    """This is the first class in the alphabeth."""
+
+    # docstr-coverage:excused `test ignore after long docstrings`
+    def ignored(self):
+        pass
+
+    def missing(self):
+        pass

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -21,6 +21,8 @@ PARTLY_EXCUSED_FILE_PATH = os.path.join(EXCUSED_SAMPLES_DIRECTORY, "partially_ex
 SAMPLES_C_DIRECTORY = os.path.join("tests", "extra_samples")
 PRIVATE_NO_DOCS_PATH = os.path.join(SAMPLES_C_DIRECTORY, "private_undocumented.py")
 
+INDIVIDUAL_SAMPLES_DIR = os.path.join("tests", "individual_samples")
+
 
 def test_should_report_for_an_empty_file():
     result = analyze([EMPTY_FILE_PATH])
@@ -261,3 +263,16 @@ def test_skip_private():
         "empty": False,
     }
     assert total_results == {"missing_count": 1, "needed_count": 2, "coverage": 50.0}
+
+
+def test_long_doc():
+    """Regression test on issue 79
+
+    Multiline docstrings can be a smoke test when checking
+    the tokenize tokens (which is based on line numbers)."""
+    result = analyze([os.path.join(INDIVIDUAL_SAMPLES_DIR, "long_doc.py")])
+    assert result.count_aggregate().coverage() == 75.0
+    assert result.count_aggregate().num_files == 1
+    # 2 + 1 inline ignore
+    assert result.count_aggregate().found == 3
+    assert result.count_aggregate().needed == 4


### PR DESCRIPTION
Fixes #79 

Explanation: 
This PR may look scary - but I'm actually convinced the removed assertion is not only not needed, but functionally wrong. The assertion was based on the assumption that each `tokenize.token` is on at most one line, which is wrong for multiline docstrings.
This wrong assumption did not lead to wrong behavior (other than the assertion error in #79)  as the actual selection of the relevant token does actually not rely on the above-mentioned assumption. 

If a more detailed explanation is required, tell me. 
