### PR TITLE
prepare release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 ...
 
 
+<a name="2.1.0"></a>
+## [2.1.0] (2021-06-23)
+
+### Features
+- Add pre-commit hook. [#78] by [bjornconstructors]
+- *Experimental:* Expose new `analyze` method, which returns fine-grained coverage reports. [#67] by [MiWeiss]
+
+### Bug Fixes
+- Remove a false AssertionError which was raised for long docstrings. [#82] by [MiWeiss]
+
+
 <a name="2.0.1"></a>
 ## [2.0.1] (2021-03-03)
 
@@ -113,7 +124,8 @@
 * Initial release
 
 
-[Unreleased]: https://github.com/HunterMcGushion/docstr_coverage/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/HunterMcGushion/docstr_coverage/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/HunterMcGushion/docstr_coverage/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/HunterMcGushion/docstr_coverage/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/HunterMcGushion/docstr_coverage/compare/v1.4.0...v2.0.0
 [1.4.0]: https://github.com/HunterMcGushion/docstr_coverage/compare/v1.3.0...v1.4.0
@@ -126,6 +138,7 @@
 
 
 [asergeant01]: https://github.com/asergeant01
+[bjornconstructors]: https://github.com/bjornconstructors
 [cthoyt]: https://github.com/cthoyt
 [econchick]: https://github.com/econchick
 [epassaro]: https://github.com/epassaro
@@ -155,3 +168,6 @@
 [#47]: https://github.com/HunterMcGushion/docstr_coverage/issues/47
 [#48]: https://github.com/HunterMcGushion/docstr_coverage/pull/48
 [#57]: https://github.com/HunterMcGushion/docstr_coverage/pull/57
+[#67]: https://github.com/HunterMcGushion/docstr_coverage/pull/67
+[#78]: https://github.com/HunterMcGushion/docstr_coverage/pull/78
+[#82]: https://github.com/HunterMcGushion/docstr_coverage/pull/82

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 
 <a name="2.1.0"></a>
-## [2.1.0] (2021-06-23)
+## [2.1.0] (2021-06-25)
 
 ### Features
 - Add pre-commit hook. [#78] by [bjornconstructors]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = "2018, Hunter McGushion"
 author = "Hunter McGushion"
 
 version = ""  # The short X.Y version
-release = "2.0.1"  # The full version, including alpha/beta/rc tags
+release = "2.1.0"  # The full version, including alpha/beta/rc tags
 
 ##################################################
 # General Configuration

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
         return f.read()
 
 
-MAJOR, MINOR, MICRO = 2, 0, 1
+MAJOR, MINOR, MICRO = 2, 1, 0
 __VERSION__ = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 
 setup(


### PR DESCRIPTION
I did not include #66 in the changelog, as it was a non-functional preparation for #67 (which is included).

I hope this helps :-)