### PR TITLE
Make the pre-commit hook always run on the same set of files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,4 @@
   types_or: [cython, pyi, python]
   minimum_pre_commit_version: "2.9.0"
   always_run: true
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -172,17 +172,18 @@ class FooBarChild(FooBar):
 
 #### Pre-commit hook
 
-You can use `docstr-coverage` as a pre-commit hook by adding the following to your `.pre-commit-config.yaml` file:
-
-To pass arguments to `docstr-coverage`, add a `.docstr.yaml` config (which is automatically picked up).
+You can use `docstr-coverage` as a pre-commit hook by adding the following to your `.pre-commit-config.yaml` file 
+and configuring the `paths` section of the [`.docstr.yaml` config](#config-file). 
  This is preferrable over [pre-commit args](https://pre-commit.com/#config-args), 
- as it facilitates the use of the same config in ci / pre-commit and manual runs.
+ as it facilitates the use of the same config in CI, pre-commit and manual runs.
 
 ```yaml
-- repo: https://github.com/HunterMcGushion/docstr_coverage
-  rev: <most recent docstr-coverage release or commit sha>
-  hooks:
-    - id: docstr-coverage
+repos:
+  - repo: https://github.com/HunterMcGushion/docstr_coverage
+    rev: v2.1.0 # most recent docstr-coverage release or commit sha
+    hooks:
+      - id: docstr-coverage
+        args: ["--verbose", "2"] # override the .docstr.yaml to see less output
 ```
 
 #### Package in Your Project

--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -290,8 +290,10 @@ def execute(paths, **kwargs):
             sys.exit(0)
         else:
             sys.exit(
-                "No Python files found "
-                "(use `--accept-empty` to exit with code 0 if you expect this case)"
+                "No Python files found. "
+                "Use `--accept-empty` to exit with code 0 if you expect this case, "
+                "or specify the paths you'd like to check "
+                "via command line arguments or the config file."
             )
 
     # Parse ignore names file


### PR DESCRIPTION
@bjornconstructors thanks for introducing the hook, we are already using it!

I have a couple improvements to the code sample. Not sure if they need to stay in the readme, or should migrate to the hook itself. 

First of all, I changed the example to explicitly specify a version tag, so that the example can be copy-pasted and work without change. 

Another cosmetic improvement is the custom verbosity level just for the hook. I've found that the error output is almost always too verbose compared to other pre-commit hooks, and at the same time we would prefer to keep it verbose for a standalone `docstr-coverage` usage. 

But the most important bit of the PR is `bash -c '...' --` workaround. By default, pre-commit appends all the file paths relevant to the current context to the command. This can produce inconsistent results, i.e. when you use `pre-commit run -a` as the CI command, or when the local hook runs on the staged diff. 

We struggled with this behavior when integrating the mypy hook, and it took some googling to find a workaround. Turns out, some tools only make sense when the set of files is predefined. I believe this change can be made to the hook itself, but I'm a bit cautious, in the end bash might not be there for some people.