### PR TITLE
Don't print fully documented file stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ docstr-coverage some_project/src
   - 1 - Print overall statistics
   - 2 - Also print individual statistics for each file
   - 3 - Also print missing docstrings (function names, class names, etc.)
+  - 4 - Also print information about present docstrings
 - _--fail-under=<int|float>, -F <int|float>_ - Fail if under a certain percentage of coverage (default: 100.0)
 - _--docstr-ignore-file=\<filepath\>, -d \<filepath\>_ - Filepath containing list of patterns to ignore. Patterns are (file-pattern, name-pattern) pairs
   - File content example:

--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -156,7 +156,7 @@ def parse_ignore_patterns_from_dict(ignore_patterns_dict) -> tuple:
 @click.option(
     "-v",
     "--verbose",
-    type=click.Choice(["0", "1", "2", "3"]),
+    type=click.Choice(["0", "1", "2", "3", "4"]),
     default="3",
     help="Verbosity level",
     show_default=True,

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -72,10 +72,20 @@ class LegacyPrinter:
 
             # List of missing docstrings
             if self.verbosity >= 3:
-                if file.status == FileStatus.EMPTY:
+                if file.status == FileStatus.EMPTY and self.verbosity > 3:
                     print_line(" - File is empty")
                 for expected_docstr in file._expected_docstrings:
-                    if not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
+                    if expected_docstr.has_docstring and self.verbosity > 3:
+                        print_line(
+                            " - Found docstring for `{0}`".format(expected_docstr.node_identifier)
+                        )
+                    elif expected_docstr.ignore_reason and self.verbosity > 3:
+                        print_line(
+                            " - Ignored `{0}`: reason: `{1}`".format(
+                                expected_docstr.node_identifier, expected_docstr.ignore_reason
+                            )
+                        )
+                    elif not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
                         if expected_docstr.node_identifier == "module docstring":
                             print_line(" - No module docstring")
                         else:

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -63,7 +63,7 @@ class LegacyPrinter:
         results: ResultCollection
             The information about docstr presence to be printed to stdout."""
         for file_path, file in results.files():
-            if file.count_aggregate().missing > 0 or file.status == FileStatus.EMPTY:
+            if self.verbosity < 4 and file.count_aggregate().missing == 0:
                 # Don't print fully documented files
                 continue
 

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -63,34 +63,37 @@ class LegacyPrinter:
         results: ResultCollection
             The information about docstr presence to be printed to stdout."""
         for file_path, file in results.files():
-            # File Header
-            print_line('\nFile: "{}"'.format(file_path))
+            if file.count_aggregate().missing > 0:
+                # File Header
+                print_line('\nFile: "{}"'.format(file_path))
 
-            # List of missing docstrings
-            if self.verbosity >= 3:
-                if file.status == FileStatus.EMPTY:
-                    print_line(" - File is empty")
-                for expected_docstr in file._expected_docstrings:
-                    if not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
-                        if expected_docstr.node_identifier == "module docstring":
-                            print_line(" - No module docstring")
-                        else:
-                            print_line(
-                                " - No docstring for `{0}`".format(expected_docstr.node_identifier)
-                            )
+                # List of missing docstrings
+                if self.verbosity >= 3:
+                    if file.status == FileStatus.EMPTY:
+                        print_line(" - File is empty")
+                    for expected_docstr in file._expected_docstrings:
+                        if not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
+                            if expected_docstr.node_identifier == "module docstring":
+                                print_line(" - No module docstring")
+                            else:
+                                print_line(
+                                    " - No docstring for `{0}`".format(
+                                        expected_docstr.node_identifier
+                                    )
+                                )
 
-            # Statistics
-            count = file.count_aggregate()
-            print_line(
-                " Needed: %s; Found: %s; Missing: %s; Coverage: %.1f%%"
-                % (
-                    count.needed,
-                    count.found,
-                    count.missing,
-                    count.coverage(),
-                ),
-            )
-            print_line()
+                # Statistics
+                count = file.count_aggregate()
+                print_line(
+                    " Needed: %s; Found: %s; Missing: %s; Coverage: %.1f%%"
+                    % (
+                        count.needed,
+                        count.found,
+                        count.missing,
+                        count.coverage(),
+                    ),
+                )
+                print_line()
         print_line()
 
     def _print_overall_statistics(self, results):

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -63,7 +63,7 @@ class LegacyPrinter:
         results: ResultCollection
             The information about docstr presence to be printed to stdout."""
         for file_path, file in results.files():
-            if file.count_aggregate().missing > 0:
+            if file.count_aggregate().missing > 0 or file.status == FileStatus.EMPTY:
                 # File Header
                 print_line('\nFile: "{}"'.format(file_path))
 

--- a/docstr_coverage/printers.py
+++ b/docstr_coverage/printers.py
@@ -64,36 +64,37 @@ class LegacyPrinter:
             The information about docstr presence to be printed to stdout."""
         for file_path, file in results.files():
             if file.count_aggregate().missing > 0 or file.status == FileStatus.EMPTY:
-                # File Header
-                print_line('\nFile: "{}"'.format(file_path))
+                # Don't print fully documented files
+                continue
 
-                # List of missing docstrings
-                if self.verbosity >= 3:
-                    if file.status == FileStatus.EMPTY:
-                        print_line(" - File is empty")
-                    for expected_docstr in file._expected_docstrings:
-                        if not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
-                            if expected_docstr.node_identifier == "module docstring":
-                                print_line(" - No module docstring")
-                            else:
-                                print_line(
-                                    " - No docstring for `{0}`".format(
-                                        expected_docstr.node_identifier
-                                    )
-                                )
+            # File Header
+            print_line('\nFile: "{}"'.format(file_path))
 
-                # Statistics
-                count = file.count_aggregate()
-                print_line(
-                    " Needed: %s; Found: %s; Missing: %s; Coverage: %.1f%%"
-                    % (
-                        count.needed,
-                        count.found,
-                        count.missing,
-                        count.coverage(),
-                    ),
-                )
-                print_line()
+            # List of missing docstrings
+            if self.verbosity >= 3:
+                if file.status == FileStatus.EMPTY:
+                    print_line(" - File is empty")
+                for expected_docstr in file._expected_docstrings:
+                    if not expected_docstr.has_docstring and not expected_docstr.ignore_reason:
+                        if expected_docstr.node_identifier == "module docstring":
+                            print_line(" - No module docstring")
+                        else:
+                            print_line(
+                                " - No docstring for `{0}`".format(expected_docstr.node_identifier)
+                            )
+
+            # Statistics
+            count = file.count_aggregate()
+            print_line(
+                " Needed: %s; Found: %s; Missing: %s; Coverage: %.1f%%"
+                % (
+                    count.needed,
+                    count.found,
+                    count.missing,
+                    count.coverage(),
+                ),
+            )
+            print_line()
         print_line()
 
     def _print_overall_statistics(self, results):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -160,7 +160,7 @@ def test_should_report_when_no_docs_in_a_file():
 def test_logging_empty_file(caplog, expected):
     with caplog.at_level(logging.DEBUG):
         result = analyze([EMPTY_FILE_PATH])
-        LegacyPrinter(verbosity=3).print(result)
+        LegacyPrinter(verbosity=4).print(result)
         _file_results, _total_results = result.to_legacy()
 
     if platform.system() == "Windows":


### PR DESCRIPTION
Outputs are overly verbose for projects with only few missing docstrings, which becomes a problem with large projects:

hundreds of lines as follows can be printed:
```
[...]
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\_stochastic\_sequential_stochastic.py"
 Needed: 4; Found: 4; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\_stochastic\_stochastic_mode.py"
 Needed: 1; Found: 1; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\_uwiz_model.py"
 Needed: 0; Found: 0; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\ensemble_utils\__init__.py"
 Needed: 0; Found: 0; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\ensemble_utils\_callables.py"
 Needed: 0; Found: 0; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\ensemble_utils\_lazy_contexts.py"
 Needed: 13; Found: 13; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\ensemble_utils\_lazy_ensemble.py"
 Needed: 7; Found: 7; Missing: 0; Coverage: 100.0%
File: "C:\Users\weiss\PycharmProjects\uncertainty-wizard\uncertainty_wizard\models\ensemble_utils\_save_config.py"
 Needed: 2; Found: 2; Missing: 0; Coverage: 100.0%
[...]
```
Now assume somewhere in there, I have one missing docstring. It requires a lot of annoying scrolling to find it. Dependent on the terminal setting, the record may not even be visible anymore. 

I thus suggest to only print files for which the coverage is < 100% (which are the ones of interest to the user).

Note: From the overall statistics, the user will still be able to read the total number of files analyzed:

```
Overall statistics for 29 files (2 files are empty) (skipped all non-init magic methods) (skipped file-level docstrings) (skipped __init__ methods) (skipped class definitions) (skipped private methods):
Needed: 100  -  Found: 100  -  Missing: 0
Total coverage: 100.0%  -  Grade: AMAZING! Your docstrings are truly a wonder to behold!
```


What's your opinion on that?

**EDIT** After discussion on slack, added a `-v 4` verbosity level, allowing to get **all** information we have for debugging.