### PR TITLE
Test Version Consistency

### DIFF
--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -28,5 +28,15 @@ def test_version_consistency():
             if line.startswith("rev:v"):
                 re_result = re.search("rev:v(.*)#mostrecent", line)
                 readme_hook_version = re_result.group(1)
+                break
 
-    assert setup_version == docs_version == readme_hook_version
+    assert (
+        setup_version == docs_version
+    ), "version in docs ({}) does not match setup.py version ({})".format(
+        docs_version, setup_version
+    )
+    assert (
+        setup_version == readme_hook_version
+    ), "version in readme ({}) does not match setup.py version ({})".format(
+        readme_hook_version, setup_version
+    )

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,0 +1,31 @@
+import re
+
+
+def test_version_consistency():
+    """Tests that all version strings are consistent."""
+
+    # Setup.py
+    setup_version = "not-parsed"
+    with open("../setup.py", "r") as setup_file:
+        for line in setup_file.readlines():
+            if line.startswith("MAJOR, MINOR, MICRO"):
+                setup_version = ".".join("".join(line.split()).split("=")[1].split(","))
+                break
+    # Documentation
+    docs_version = "not-parsed"
+    with open("../docs/conf.py", "r") as setup_file:
+        for line in setup_file.readlines():
+            if line.startswith("release = "):
+                docs_version = line.split('"')[1]
+                break
+    # Pre-Commit Example in README.md
+    readme_hook_version = "not-parsed"
+    with open("../README.md", "r") as setup_file:
+        for line in setup_file.readlines():
+            # remove spaces
+            line = "".join(line.split())
+            if line.startswith("rev:v"):
+                re_result = re.search("rev:v(.*)#mostrecent", line)
+                readme_hook_version = re_result.group(1)
+
+    assert setup_version == docs_version == readme_hook_version

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -6,21 +6,21 @@ def test_version_consistency():
 
     # Setup.py
     setup_version = "not-parsed"
-    with open("../setup.py", "r") as setup_file:
+    with open("setup.py", "r") as setup_file:
         for line in setup_file.readlines():
             if line.startswith("MAJOR, MINOR, MICRO"):
                 setup_version = ".".join("".join(line.split()).split("=")[1].split(","))
                 break
     # Documentation
     docs_version = "not-parsed"
-    with open("../docs/conf.py", "r") as setup_file:
+    with open("docs/conf.py", "r") as setup_file:
         for line in setup_file.readlines():
             if line.startswith("release = "):
                 docs_version = line.split('"')[1]
                 break
     # Pre-Commit Example in README.md
     readme_hook_version = "not-parsed"
-    with open("../README.md", "r") as setup_file:
+    with open("README.md", "r") as setup_file:
         for line in setup_file.readlines():
             # remove spaces
             line = "".join(line.split())

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,3 +1,4 @@
+"""Nonfunctional tests regarding manual configuration."""
 import re
 
 


### PR DESCRIPTION
A small utility test checking that all mentioned versions are consistent. That's hopefully helpful when building releases.

The way it's implemented is quite hacky, but I think it's still a valuable sanity check.