### PR TITLE
tqdm progress bar

### DIFF
--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -323,7 +323,8 @@ def execute(paths, **kwargs):
     )
 
     # Calculate docstring coverage
-    results = analyze(all_paths, ignore_config=ignore_config)
+    show_progress = not kwargs["percentage_only"]
+    results = analyze(all_paths, ignore_config=ignore_config, show_progress=show_progress)
 
     LegacyPrinter(verbosity=kwargs["verbose"], ignore_config=ignore_config).print(results)
 

--- a/docstr_coverage/coverage.py
+++ b/docstr_coverage/coverage.py
@@ -5,6 +5,8 @@ import re
 from ast import parse
 from typing import Dict, List, Tuple
 
+from tqdm import tqdm
+
 from docstr_coverage.ignore_config import IgnoreConfig
 from docstr_coverage.printers import LegacyPrinter
 from docstr_coverage.result_collection import File, FileStatus, ResultCollection
@@ -209,7 +211,9 @@ def get_docstring_coverage(
     return results.to_legacy()
 
 
-def analyze(filenames: list, ignore_config: IgnoreConfig = IgnoreConfig()) -> ResultCollection:
+def analyze(
+    filenames: list, ignore_config: IgnoreConfig = IgnoreConfig(), show_progress=True
+) -> ResultCollection:
     """EXPERIMENTAL: More expressive alternative to `get_docstring_coverage`.
 
         Checks contents of `filenames` for missing docstrings, and produces a report detailing
@@ -226,13 +230,26 @@ def analyze(filenames: list, ignore_config: IgnoreConfig = IgnoreConfig()) -> Re
         ignore_config: IgnoreConfig
             Information about which docstrings are to be ignored
 
+        show_progress: Boolean, default=True
+            If True, prints a progress bar to stdout
+
     Returns
     -------
     ResultCollection
         The collected information about docstring presence"""
     results = ResultCollection()
 
-    for filename in filenames:
+    iterator = iter(filenames)
+    if show_progress:
+        iterator = tqdm(
+            iterator,
+            desc="Checking python files",
+            unit="files",
+            unit_scale=True,
+            total=len(filenames),
+        )
+
+    for filename in iterator:
         file_result = results.get_file(file_path=filename)
 
         ##################################################

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email="hunter@mcgushion.com",
     license="MIT",
     packages=["docstr_coverage"],
-    install_requires=["click", "PyYAML"],
+    install_requires=["click", "PyYAML", "tqdm==4.63.1"],
     extras_require={
         "lint": ["flake8==3.9.2", "black==21.5b2", "isort==5.9.0"],
         "test": ["pytest==5.4.2", "pytest-mock==3.4.0"],


### PR DESCRIPTION
When running docstr-coverage on large projects, the console output appears frozen. 

This PR thus adds a progress bar (always shown, except when `percentage-only` is set). I needed to add an additional dependency (tqdm) but I guess that's affordable. 