### PR TITLE
feat: GitHub and JSON formatted printers

### DIFF
--- a/docstr_coverage/cli.py
+++ b/docstr_coverage/cli.py
@@ -13,7 +13,7 @@ from docstr_coverage.badge import Badge
 from docstr_coverage.config_file import set_config_defaults
 from docstr_coverage.coverage import analyze
 from docstr_coverage.ignore_config import IgnoreConfig
-from docstr_coverage.printers import LegacyPrinter
+from docstr_coverage.printers import GitHubCommentPrinter, JsonPrinter, LegacyPrinter
 
 
 def do_include_filepath(filepath: str, exclude_re: Optional["re.Pattern"]) -> bool:
@@ -261,6 +261,15 @@ def parse_ignore_patterns_from_dict(ignore_patterns_dict) -> tuple:
     default=".docstr_coverage",
     help="Deprecated. Use json config (--config / -C) instead",
 )
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["text", "json", "github-comment"]),
+    default="text",
+    help="Formatting style of the output (text, json, github-comment)",
+    show_default=True,
+    metavar="FORMAT",
+)
 def execute(paths, **kwargs):
     """Measure docstring coverage for `PATHS`"""
 
@@ -328,7 +337,14 @@ def execute(paths, **kwargs):
     show_progress = not kwargs["percentage_only"]
     results = analyze(all_paths, ignore_config=ignore_config, show_progress=show_progress)
 
-    LegacyPrinter(verbosity=kwargs["verbose"], ignore_config=ignore_config).print(results)
+    if kwargs["output"] == "json":
+        printer = JsonPrinter()
+    elif kwargs["output"] == "github-comment":
+        printer = GitHubCommentPrinter(verbosity=kwargs["verbose"], fail_under=kwargs["fail_under"])
+    else:
+        printer = LegacyPrinter(verbosity=kwargs["verbose"], ignore_config=ignore_config)
+
+    printer.print(results)
 
     file_results, total_results = results.to_legacy()
 

--- a/docstr_coverage/result_collection.py
+++ b/docstr_coverage/result_collection.py
@@ -5,6 +5,7 @@ import abc
 import enum
 import functools
 import operator
+import os
 from typing import Optional
 
 


### PR DESCRIPTION
The issue with `print_lines` using `logger.info` still persists. The issue being that `docstr_coverage > results.txt` does contain the progress bar. I suggest either add a parameter for an output file or remove the progress bar.

This is how it looks like:

## [:books: docstr_coverage](https://docstr-coverage.readthedocs.io/en/latest/api_essentials.html) status: :x: **FAILED**

Overall coverage: **`76%`** (required **`80%`**)

<details><summary>Additional details and impacted files</summary>

| Filename                                              |   Needed |   Found |   Missing |   Coverage |
|:------------------------------------------------------|---------:|--------:|----------:|-----------:|
| :x: `docstr_coverage/__init__.py`                     |        1 |       0 |         1 |       0.0% |
| :white_check_mark: `docstr_coverage/badge.py`         |        7 |       6 |         1 |      85.7% |
| :x: `docstr_coverage/cli.py`                          |        9 |       7 |         2 |      77.8% |
| :white_check_mark: `docstr_coverage/config_file.py`   |        3 |       3 |         0 |     100.0% |
| :white_check_mark: `docstr_coverage/coverage.py`      |        5 |       5 |         0 |     100.0% |
| :white_check_mark: `docstr_coverage/ignore_config.py` |       12 |      11 |         1 |      91.7% |
| :x: `docstr_coverage/printers.py`                     |       16 |       9 |         7 |      56.2% |
| :x: `docstr_coverage/result_collection.py`            |       29 |      20 |         9 |      69.0% |
| :white_check_mark: `docstr_coverage/visitor.py`       |       14 |      12 |         2 |      85.7% |
</details>